### PR TITLE
Use int arithmetics for timeout calculation in recvfrom_wto

### DIFF
--- a/src/fping.c
+++ b/src/fping.c
@@ -2623,6 +2623,7 @@ select_again:
   Description:
 
   receive with timeout
+  timeout is in hundredths of milliseconds ie, tens of microseconds
   returns length of data read or -1 if timeout
   crash_and_burn on any other errrors
 
@@ -2630,17 +2631,13 @@ select_again:
 
 int recvfrom_wto( int s, char *buf, int len, FPING_SOCKADDR *saddr, long timo )
 {
-        unsigned int slen;
+    unsigned int slen;
     int nfound, n;
     struct timeval to;
     fd_set readset, writeset;
 
-    to.tv_sec = 0;
-    to.tv_usec = timo * 10;
-    while (to.tv_usec > 1000000) {
-        to.tv_sec++;
-        to.tv_usec -= 1000000;
-    }
+    to.tv_sec  = timo / 100000 ;
+    to.tv_usec = (timo % 100000) * 10 ;
 
     FD_ZERO( &readset );
     FD_ZERO( &writeset );


### PR DESCRIPTION
HI,

The fix for timeout issue on Solaris introduced in 8047122e854ce3abca5b998a26520394fdbc24bf uses loop for timeout calculation. I think, it is rather ineffective. I've rewritten it with integer arithmetics. Please let me know if I miss something.

Best regards,
Andrey Bondarenko
