### PR TITLE
Bugfix for infinite loop

### DIFF
--- a/src/fping.c
+++ b/src/fping.c
@@ -1104,12 +1104,12 @@ void main_loop()
                 lt = timeval_diff( &current_time, &last_send_time );
                 if(lt < interval) goto wait_for_reply;
 
-                /* Dequeue the event */
-                h = ev_dequeue();
-
                 /* Send the ping */
 		/*printf("Sending ping after %d ms\n", lt/100); */
-                if(!send_ping(s, h)) goto wait_for_reply;
+                if(!send_ping(s, ev_first)) goto wait_for_reply;
+
+                /* Dequeue the event */
+                h = ev_dequeue();
 
                 /* Check what needs to be done next */
                 if(!loop_flag && !count_flag) {
@@ -2768,6 +2768,7 @@ HOST_ENTRY *ev_dequeue()
     }
     dequeued = ev_first;
     ev_remove(dequeued);
+    dequeued->ev_next=dequeued->ev_prev=NULL;
 
     return dequeued;
 }
@@ -2791,6 +2792,7 @@ void ev_remove(HOST_ENTRY *h)
     if(h->ev_next) {
         h->ev_next->ev_prev = h->ev_prev;
     }
+    h->ev_next=h->ev_prev=NULL;
 }
 
 


### PR DESCRIPTION
The first two commits are a rollback of my previous proposal and merge with your changes.

The second tries to make the timeout calculations unified in all places and avoids the % in favor of \* and -.

The third commit fixes a corruption of the linked list - there are several issues:
- send_ping removes the entry from the list and if the entry is already dequeued it will corrupt the list on error
- dequeue and remove do not modify ev_next and ev_prev while the functions that add items to the list rely on NULL values

In the output below it is clearly seen how the list is converted to a circle with all ev_prev==NULL

(gdb) print num_timeout 
$27 = 36457670
(gdb) print num_jobs 
$28 = -36457671
(gdb) print *ev_first
$29 = {ev_prev = 0x0, ev_next = 0x1ba67a0, ev_time = {tv_sec = 1337617783, tv_usec = 810555}, ev_type = 2, i = 2, 
  name = 0x1ba65c0 "192.168.241.21", host = 0x1ba65c0 "192.168.241.21", pad = 0x0, saddr = {sin_family = 2, sin_port = 0, 
    sin_addr = {s_addr = 368158912}, sin_zero = "\000\000\000\000\000\000\000"}, timeout = 150, running = 0 '\000', 
  waiting = 0 '\000', last_send_time = {tv_sec = 1337617783, tv_usec = 809055}, num_sent = 2, num_recv = 0, max_reply = 0, 
  min_reply = 10000000, total_time = 0, num_sent_i = 2, num_recv_i = 0, max_reply_i = 0, min_reply_i = 0, total_time_i = 0, 
  resp_times = 0x1ba6680}
(gdb) print *ev_first->ev_next
$30 = {ev_prev = 0x0, ev_next = 0x1ba6880, ev_time = {tv_sec = 1337617783, tv_usec = 812616}, ev_type = 2, i = 4, 
  name = 0x1ba6780 "192.168.253.9", host = 0x1ba6780 "192.168.253.9", pad = 0x0, saddr = {sin_family = 2, sin_port = 0, sin_addr = {
      s_addr = 167618752}, sin_zero = "\000\000\000\000\000\000\000"}, timeout = 100, running = 0 '\000', waiting = 0 '\000', 
  last_send_time = {tv_sec = 1337617783, tv_usec = 811116}, num_sent = 2, num_recv = 2, max_reply = 3853, min_reply = 3742, 
  total_time = 7595, num_sent_i = 2, num_recv_i = 2, max_reply_i = 3853, min_reply_i = 0, total_time_i = 7595, 
  resp_times = 0x1ba6840}
(gdb) print *ev_first->ev_next->ev_next
$31 = {ev_prev = 0x0, ev_next = 0x1ba65e0, ev_time = {tv_sec = 1337617783, tv_usec = 813672}, ev_type = 2, i = 5, 
  name = 0x1ba6860 "192.168.242.20", host = 0x1ba6860 "192.168.242.20", pad = 0x0, saddr = {sin_family = 2, sin_port = 0, 
    sin_addr = {s_addr = 351447232}, sin_zero = "\000\000\000\000\000\000\000"}, timeout = 150, running = 0 '\000', 
  waiting = 0 '\000', last_send_time = {tv_sec = 1337617783, tv_usec = 812172}, num_sent = 2, num_recv = 0, max_reply = 0, 
  min_reply = 10000000, total_time = 0, num_sent_i = 2, num_recv_i = 0, max_reply_i = 0, min_reply_i = 0, total_time_i = 0, 
  resp_times = 0x1ba6920}
(gdb) print *ev_first->ev_next->ev_next->ev_next
$32 = {ev_prev = 0x0, ev_next = 0x1ba67a0, ev_time = {tv_sec = 1337617783, tv_usec = 810555}, ev_type = 2, i = 2, 
  name = 0x1ba65c0 "192.168.241.21", host = 0x1ba65c0 "192.168.241.21", pad = 0x0, saddr = {sin_family = 2, sin_port = 0, 
    sin_addr = {s_addr = 368158912}, sin_zero = "\000\000\000\000\000\000\000"}, timeout = 150, running = 0 '\000', 
  waiting = 0 '\000', last_send_time = {tv_sec = 1337617783, tv_usec = 809055}, num_sent = 2, num_recv = 0, max_reply = 0, 
  min_reply = 10000000, total_time = 0, num_sent_i = 2, num_recv_i = 0, max_reply_i = 0, min_reply_i = 0, total_time_i = 0, 
  resp_times = 0x1ba6680}
