### PR TITLE
Add --with-ipv4 and --with-ipv6 options to cnfigure 

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5,6 +5,29 @@ AC_PREREQ(2.59)
 
 AC_INIT([fping],[3.3rc1])
 
+dnl make ipv4 and ipv6 options
+AC_ARG_ENABLE([ipv4],
+  [  --enable-ipv4    Build IPv4 capable fping],
+  [case "${enableval}" in
+   yes)	ipv4=true ;;
+   no)	ipv4=false ;;
+   *)	AC_MSG_ERROR([bad value ${enableval} for --enable-ipv4]) ;;
+   esac],[ipv4=true])
+  AM_CONDITIONAL([IPV4], [test x$ipv4 = xtrue])
+
+AC_ARG_ENABLE([ipv6],
+  [  --enable-ipv6    Build IPv6 capable fping6],
+  [case "${enableval}" in
+   yes)	ipv6=true ;;
+   no)	ipv6=false ;;
+   *)	AC_MSG_ERROR([bad value ${enableval} for --enable-ipv6]) ;;
+   esac],[ipv6=false])
+  AM_CONDITIONAL([IPV6], [test x$ipv6 = xtrue])
+
+if test x$ipv4 = xfalse && test x$ipv6 = xfalse; then
+  AC_MSG_ERROR([You must enable at least one of IPv4 and IPv6.])
+fi
+
 AC_CANONICAL_TARGET
 AM_INIT_AUTOMAKE([foreign])
 AM_MAINTAINER_MODE

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,3 +1,16 @@
-sbin_PROGRAMS = fping
+prog =
+
+if IPV4
+prog += fping
+endif
+if IPV6
+prog += fping6
+endif
+
+sbin_PROGRAMS = ${prog}
+
 fping_SOURCES = fping.c options.h
 fping_DEPENDENCIES = ../config.h
+fping6_SOURCES = fping.c options.h
+fping6_DEPENDENCIES = ../config.h
+fping6_CFLAGS = $(AM_CFLAGS) -DIPV6


### PR DESCRIPTION
Currently, to get IPv6 fping you have to pass -DIPV6 to to make while
compiling, and the resulting fping will not handle ipv4.  This patch
adds --with-ipv4 (enabled by default) and --with-ipv6 (disabled by
default) that gives a IPv4 capable fping, and a IPv6 capable fping6
respectively.  Both can be enabled, or either one.  If both the IPv4 and
the IPv6 versions are disabled, configure will throw an error.
