### PR TITLE
Add manual for fping6, from fping.pod

### DIFF
--- a/autoclean.sh
+++ b/autoclean.sh
@@ -19,3 +19,5 @@ rm -f stamp-h1
 rm -f doc/Makefile.in
 rm -f src/Makefile.in
 rm -f doc/fping.8
+rm -f doc/fping6.8
+rm -f doc/fping6.8.bak

--- a/configure.ac
+++ b/configure.ac
@@ -39,6 +39,7 @@ dnl Checks for programs.
 AC_PROG_CC
 AC_PROG_CPP
 AC_PROG_INSTALL
+AC_PROG_SED
 
 dnl Checks for libraries.
 

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -1,6 +1,24 @@
-man_MANS = fping.8
-EXTRA_DIST = $(man_MANS) fping.pod README.1992
+man =
+
+if IPV4
+man += fping.8
+endif
+if IPV6
+man += fping6.8
+endif
+
+man_MANS = $(man)
+EXTRA_DIST = fping.pod README.1992
+
 
 fping.8: fping.pod
 	pod2man $< >$@
-	pod2man  -c "" -s 8 -r "fping $(VERSION)" $< >$@
+	pod2man  -c "" -s 8 -r "fping $(VERSION)" -n FPING $< >$@
+
+fping6.8: fping.pod
+	pod2man $< >$@
+	pod2man -c "" -s 8 -r "fping $(VERSION)" -n FPING6 $< >$@
+	${SED} -i.bak -e 's/fping/fping6/' fping6.8
+
+clean:
+	${RM} ${man_MANS} fping6.8.bak


### PR DESCRIPTION
This manual is generated from the same fping.pod as the fping.8 manual.
Sed is then used to s/fping/fping6/ in fping6.8.  This manual is only
installed if fping is configured with --enable-ipv6.  At the same time,
change so that fping.8 (IPv4 manual) is only installed if fping is
configured with --enable-ipv4 (default).
Add a check to configure for a working sed as well, since that's used
here.
