### PR TITLE
Add -D flag to print timestamp in front of output lines.

### DIFF
--- a/src/fping.c
+++ b/src/fping.c
@@ -1829,7 +1829,7 @@ int wait_for_reply(long wait_time)
     if( per_recv_flag )
     {
         if(timestamp_flag) {
-            printf("[%lu.%04lu] ",
+            printf("[%lu.%06lu] ",
                  (unsigned long)current_time.tv_sec,
                  (unsigned long)current_time.tv_usec);
         }


### PR DESCRIPTION
I'm looking to support fping as an ICMP measurement tool in the netperf-wrappers utility for testing bufferbloat (see https://github.com/tohojo/netperf-wrappers). In order to do this, I need to be able to timestamp output, to correlate it with bandwidth measurements.

This pull request contains a patch to add a -D flag which will print a UNIX timestamp before each output line, similar to how the Linux `ping` utility works.
