### PR TITLE
Be more precise when clarifying issue reported in #87

### DIFF
--- a/README
+++ b/README
@@ -20,7 +20,7 @@ Installation
 If you want to install fping from source, proceed as follows:
 
 0. Run ./autogen.sh
-   (only if you got the source from github)
+   (only needed if you got the source code by cloning a git repository)
 
 1. Run ./configure with the correct arguments
    (see: ./configure --help)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ _Mailing-list_:
 If you want to install fping from source, proceed as follows:
 
 0. Run ./autogen.sh
-   (only if you got the source from github)
+   (only needed if you got the source code by cloning a git repository)
 1. Run ./configure with the correct arguments
    (see: ./configure --help)
 2. Run make; make install


### PR DESCRIPTION
"getting the source from github" could also be interpreted as
downloading released source tar balls from
https://github.com/schweikert/fping/releases -- where it doesn't apply.

The actual relevant difference is not "github or not github" but
"release tar ball or git clone".