### PR TITLE
added changes for accumulated outage time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
 compiler:
     - gcc
 before_install:
+    - sudo apt-get update -qq
     - sudo apt-get install libcap2-bin
     - sudo apt-get install traceroute
     - traceroute google.com

--- a/ci/test-02-help.pl
+++ b/ci/test-02-help.pl
@@ -28,6 +28,7 @@ Usage: fping [options] [targets...]
 ${I_HELP}   -l         loop sending pings forever
    -m         ping multiple interfaces on target host
    -n         show targets by name (-d is equivalent)
+   -o         show the accumulated outage time (lost packets * packet interval [option -i])
    -O n       set the type of service (tos) flag on the ICMP packets
    -p n       interval between ping packets to one target (in millisec)
                 (in looping and counting modes, default 1000)


### PR DESCRIPTION
Hi David,
I really enjoy using fping. It is a great tool. I often have to do network convergence tests. When not using a professional traffic generator, the easiest option is to send many ping packets (e.g. 1 ping every 100ms) and measure how many ping packets were lost during the failure. Therefore, I added a new option (-o) that calculates how much outage you have observed based on the number of lost packets and the inter-packet interval. 

I tested this new option along side the traditional testing tool (home made perl script) and we observed the same results. I really hope this feature can become a part of the mainline fping program.
Thanks for all your work,
Jan