### PR TITLE
add path mtu discovert (MTU) AKA Don't Fragment support

### DIFF
--- a/src/fping.c
+++ b/src/fping.c
@@ -377,10 +377,19 @@ int main( int argc, char **argv )
 
     /* get command line options */
 
-    while( ( c = getopt( argc, argv, "gedhlmnqusaAvDRz:t:H:i:p:f:r:c:b:C:Q:B:S:I:T:O:" ) ) != EOF )
+    while( ( c = getopt( argc, argv, "gedhlmnqusaAvDRz:t:H:i:p:f:r:c:b:C:Q:B:S:I:T:O:M" ) ) != EOF )
     {
         switch( c )
         {
+        case 'M':
+            {
+            int val = IP_PMTUDISC_DO;
+            if (setsockopt(s, IPPROTO_IP, IP_MTU_DISCOVER, &val, sizeof(val))) {
+                perror("setsockopt IP_MTU_DISCOVER");
+            }
+            }
+            break;
+
         case 't':
             if( !( timeout = ( unsigned int )atoi( optarg ) * 100 ) )
                 usage(1);
@@ -2380,6 +2389,7 @@ void usage(int is_error)
 #endif
     fprintf(out, "   -l         loop sending pings forever\n" );
     fprintf(out, "   -m         ping multiple interfaces on target host\n" );
+    fprintf(out, "   -M         Don't Fragment (IP_PMTUDISC_DO)\n" );
     fprintf(out, "   -n         show targets by name (-d is equivalent)\n" );
     fprintf(out, "   -O n       set the type of service (tos) flag on the ICMP packets\n" );
     fprintf(out, "   -p n       interval between ping packets to one target (in millisec)\n" );


### PR DESCRIPTION
This option is very useful for checking MTU blackholes. Since fping is good at checking multiple servers @ once, together its good in a cloud hosting environment where you have a lot of hosts that need to reach each other at slightly larger than standard ethernet sizes (e.g. to handle vxlan overhead), and sometimes one server is misconfigured or one switch port.
