### PR TITLE
Issue compliling on RHEL/Centos 7

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -37,6 +37,7 @@ AC_CONFIG_HEADERS([config.h])
 dnl Checks for programs.
 
 AC_PROG_CC
+AM_PROG_CC_C_O
 AC_PROG_CPP
 AC_PROG_INSTALL
 


### PR DESCRIPTION
warning: compiling 'fping.c' with per-target flags requires 'AM_PROG_CC_C_O' in 'configure.ac'