### PR TITLE
Ignore network and broadcast for cidrs /31 and /32

### DIFF
--- a/ci/test-06-options-f-h.pl
+++ b/ci/test-06-options-f-h.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 
-use Test::Command tests => 18;
+use Test::Command tests => 24;
 use File::Temp;
 
 #  -f file    read list of targets from a file ( - means stdin) (only if no -g specified)
@@ -51,6 +51,22 @@ my $cmd = Test::Command->new(cmd => "fping -g 127.0.0.1/30");
 $cmd->exit_is_num(0);
 $cmd->stdout_is_eq("127.0.0.1 is alive\n127.0.0.2 is alive\n");
 $cmd->stderr_is_eq("");
+}
+
+# fping -g (cidr - long prefixes)
+{
+my $cmd = Test::Command->new(cmd => "fping -g 127.0.0.2/31");
+$cmd->exit_is_num(0);
+$cmd->stdout_is_eq("127.0.0.2 is alive\n127.0.0.3 is alive\n");
+$cmd->stderr_is_eq("");
+}
+
+# fping -g (cidr - too long prefixes)
+{
+my $cmd = Test::Command->new(cmd => "fping -g 127.0.0.2/33");
+$cmd->exit_is_num(1);
+$cmd->stdout_is_eq("");
+$cmd->stderr_is_eq("Error: netmask must be between 1 and 32 (is: 33)\n");
 }
 
 # fping -H


### PR DESCRIPTION
fping has previously been strict about network address and broadcast
addreses. In the commit this is loosened a bit to permit fping to ping
cidrs with prefix length 31, which are commonly used for link ranges
(for newer equipment) and length 32 which denotes a single ip address.

For prefix lengths 31 and 32 fping will simply ignore network address
and broadcast addresses, and consider all addresses in range as a
target.