### PR TITLE
added option -N to allow fping output statistics in the format expected by netdata

### DIFF
--- a/src/fping.c
+++ b/src/fping.c
@@ -2524,6 +2524,7 @@ void usage(int is_error)
     fprintf(out, "   -m         ping multiple interfaces on target host\n" );
     fprintf(out, "   -M         set the Don't Fragment flag\n" );
     fprintf(out, "   -n         show targets by name (-d is equivalent)\n" );
+    fprintf(out, "   -N         output compatible for netdata (-l -Q are required)\n" );
     fprintf(out, "   -o         show the accumulated outage time (lost packets * packet interval)\n" );
     fprintf(out, "   -O n       set the type of service (tos) flag on the ICMP packets\n" );
     fprintf(out, "   -p n       interval between ping packets to one target (in millisec)\n" );

--- a/src/fping.c
+++ b/src/fping.c
@@ -1324,22 +1324,22 @@ void print_netdata( void )
         h = table[i];
 
         if(!sent_charts) {
-            printf("CHART fping_%s.packets '' 'FPing Packets for host %s' packets 'packets' fping.packets line 70020 %d\n", h->name, h->host, report_interval / 100000);
+            printf("CHART fping.%s_packets '' 'FPing Packets for host %s' packets '%s' fping.packets line 110020 %d\n", h->name, h->host, h->name, report_interval / 100000);
             printf("DIMENSION xmt sent absolute 1 1\n");
             printf("DIMENSION rcv received absolute 1 1\n");
         }
 
-        printf("BEGIN fping_%s.packets\n", h->name);
+        printf("BEGIN fping.%s_packets\n", h->name);
         printf("SET xmt = %d\n", h->num_sent_i);
         printf("SET rcv = %d\n", h->num_recv_i);
         printf("END\n");
 
         if(!sent_charts) {
-            printf("CHART fping_%s.loss '' 'FPing Packet Loss for host %s' percentage loss fping.loss line 70010 %d\n", h->name, h->host, report_interval / 100000);
+            printf("CHART fping.%s_loss '' 'FPing Packet Loss for host %s' percentage '%s' fping.loss line 110010 %d\n", h->name, h->host, h->name, report_interval / 100000);
             printf("DIMENSION pcent '' absolute 1 1\n");
         }
 
-        printf("BEGIN fping_%s.loss\n", h->name);
+        printf("BEGIN fping.%s_loss\n", h->name);
         if( h->num_recv_i <= h->num_sent_i )
         {
             printf("SET pcent = %d\n", h->num_sent_i > 0 ?
@@ -1361,13 +1361,13 @@ void print_netdata( void )
         printf("END\n");
 
         if(!sent_charts) {
-            printf("CHART fping_%s.latency '' 'FPing Latency for host %s' ms latency fping.latency line 70000 %d\n", h->name, h->host, report_interval / 100000);
+            printf("CHART fping.%s_latency '' 'FPing Latency for host %s' ms '%s' fping.latency line 110000 %d\n", h->name, h->host, h->name, report_interval / 100000);
             printf("DIMENSION min minimum absolute 10 1000\n");
             printf("DIMENSION max maximum absolute 10 1000\n");
             printf("DIMENSION avg average absolute 10 1000\n");
         }
 
-        printf("BEGIN fping_%s.latency\n", h->name);
+        printf("BEGIN fping.%s_latency\n", h->name);
         if( h->num_recv_i )
         {
             avg = h->total_time_i / h->num_recv_i;

--- a/src/fping.c
+++ b/src/fping.c
@@ -1305,7 +1305,7 @@ void print_netdata( void )
 {
     static int sent_charts = 0;
 
-    int i, avg /*, outage_ms_i */;
+    int i, avg;
     HOST_ENTRY *h;
     char *buf;
     int bufsize;
@@ -1337,25 +1337,16 @@ void print_netdata( void )
         if(!sent_charts) {
             printf("CHART fping.%s_quality '' 'FPing Quality for host %s' percentage '%s' fping.quality line 110010 %d\n", h->name, h->host, h->name, report_interval / 100000);
             printf("DIMENSION returned '' absolute 1 1\n");
-            printf("DIMENSION lost '' absolute 1 1\n");
+            /* printf("DIMENSION lost '' absolute 1 1\n"); */
         }
 
         printf("BEGIN fping.%s_quality\n", h->name);
+/*
         if( h->num_recv_i <= h->num_sent_i )
-        {
             printf("SET lost = %d\n", h->num_sent_i > 0 ? ( ( h->num_sent_i - h->num_recv_i ) * 100 ) / h->num_sent_i : 0 );
-
-/*            if (outage_flag) {
-                // Time outage
-                outage_ms_i = (h->num_sent_i - h->num_recv_i) * perhost_interval/100;
-                fprintf( stderr, ", outage(ms) = %d", outage_ms_i );
-            }
-*/
-        }/* IF */
         else
-        {
             printf("SET lost = 0\n");
-        }/* ELSE */
+*/
 
         printf("SET returned = %d\n", h->num_sent_i > 0 ? ( ( h->num_recv_i * 100 ) / h->num_sent_i ) : 0 );
         printf("END\n");

--- a/src/fping.c
+++ b/src/fping.c
@@ -1335,15 +1335,15 @@ void print_netdata( void )
         printf("END\n");
 
         if(!sent_charts) {
-            printf("CHART fping.%s_loss '' 'FPing Packet Loss for host %s' percentage '%s' fping.loss line 110010 %d\n", h->name, h->host, h->name, report_interval / 100000);
-            printf("DIMENSION pcent '' absolute 1 1\n");
+            printf("CHART fping.%s_quality '' 'FPing Quality for host %s' percentage '%s' fping.quality line 110010 %d\n", h->name, h->host, h->name, report_interval / 100000);
+            printf("DIMENSION returned '' absolute 1 1\n");
+            printf("DIMENSION lost '' absolute 1 1\n");
         }
 
-        printf("BEGIN fping.%s_loss\n", h->name);
+        printf("BEGIN fping.%s_quality\n", h->name);
         if( h->num_recv_i <= h->num_sent_i )
         {
-            printf("SET pcent = %d\n", h->num_sent_i > 0 ?
-                                                  ( ( h->num_sent_i - h->num_recv_i ) * 100 ) / h->num_sent_i : 0 );
+            printf("SET lost = %d\n", h->num_sent_i > 0 ? ( ( h->num_sent_i - h->num_recv_i ) * 100 ) / h->num_sent_i : 0 );
 
 /*            if (outage_flag) {
                 // Time outage
@@ -1354,10 +1354,10 @@ void print_netdata( void )
         }/* IF */
         else
         {
-            printf("SET pcent = %d\n", h->num_sent_i > 0 ?
-                                                  ( ( h->num_recv_i * 100 ) / h->num_sent_i ) : 0 );
-
+            printf("SET lost = 0\n");
         }/* ELSE */
+
+        printf("SET returned = %d\n", h->num_sent_i > 0 ? ( ( h->num_recv_i * 100 ) / h->num_sent_i ) : 0 );
         printf("END\n");
 
         if(!sent_charts) {


### PR DESCRIPTION
Hi,

I am the founder of firehol.org and https://github.com/firehol/netdata (http://my-netdata.io).

This PR adds the option `-N` to `fping` to allow it output statistics in a netdata friendly format.

**For each host** given, netdata will create 3 charts, like that:

![image](https://cloud.githubusercontent.com/assets/2662304/19414082/df38e2c6-934a-11e6-9097-159db1e14425.png)

A wrapper script (`/usr/libexec/netdata/plugins.d/fping.plugin`) is required only for passing the valid options to fping. It is shown below and I'll add it to the netdata repo:

``` sh
#!/usr/bin/env bash

me="${0}"

# the frequency to send info to netdata
# passed by netdata as the first parameter
update_every="${1-1}"

# the netdata configuration directory
# passed by netdata as an environment variable
NETDATA_CONFIG_DIR="${NETDATA_CONFIG_DIR-/etc/netdata}"

# -----------------------------------------------------------------------------
# configuration options
# can be overwritten at /etc/netdata/fping.conf

# the fping binary to use
# we need one that can output netdata friendly info
fping="$(which fping || command -v fping)"

# a space separated list of hosts to fping
hosts=""

# the time in milliseconds (1 sec = 1000 ms)
# to ping the hosts - by default 2 pings per iteration
ping_every="$((update_every * 1000 / 2))"

# how many retries to make if a host does not respond
retries=1

# -----------------------------------------------------------------------------

# load the configuration file
if [ ! -f "${NETDATA_CONFIG_DIR}/fping.conf" ]
then
    echo >&2 "${me}: configuration file '${NETDATA_CONFIG_DIR}/fping.conf' not found - nothing to do."
    echo "DISABLE"
    exit 1
fi

source "${NETDATA_CONFIG_DIR}/fping.conf"

if [ -z "${hosts}" ]
then
    echo >&2 "${me}: no hosts configued in '${NETDATA_CONFIG_DIR}/fping.conf' - nothing to do."
    echo "DISABLE"
    exit 1
fi

if [ -z "${fping}" -o ! -x "${fping}" ]
then
    echo >&2 "${me}: command '${fping}' is not executable - cannot proceed."
    echo "DISABLE"
    exit 1
fi

# the fping options we will use
options=( -N -l -R -Q ${update_every} -p ${ping_every} -r ${retries} ${hosts} )

# execute fping
exec "${fping}" "${options[@]}"

# if we cannot execute fping, stop
echo >&2 "${me}: command '${fping} ${options[@]}' failed to be executed."
echo "DISABLE"
exit 1
```

cc: https://github.com/firehol/netdata/issues/1122
