### PR TITLE
minor netdata improvements

### DIFF
--- a/ci/test-15-netdata.pl
+++ b/ci/test-15-netdata.pl
@@ -16,12 +16,12 @@ BEGIN fping\.127_0_0_1_packets
 SET xmt = 1
 SET rcv = 1
 END
-CHART fping\.127_0_0_1_quality '' 'FPing Quality for host 127\.0\.0\.1' percentage '127_0_0_1' fping\.quality line 110010 1
+CHART fping\.127_0_0_1_quality '' 'FPing Quality for host 127\.0\.0\.1' percentage '127_0_0_1' fping\.quality area 110010 1
 DIMENSION returned '' absolute 1 1
 BEGIN fping\.127_0_0_1_quality
 SET returned = 100
 END
-CHART fping\.127_0_0_1_latency '' 'FPing Latency for host 127\.0\.0\.1' ms '127_0_0_1' fping\.latency line 110000 1
+CHART fping\.127_0_0_1_latency '' 'FPing Latency for host 127\.0\.0\.1' ms '127_0_0_1' fping\.latency area 110000 1
 DIMENSION min minimum absolute 10 1000
 DIMENSION max maximum absolute 10 1000
 DIMENSION avg average absolute 10 1000

--- a/src/fping.c
+++ b/src/fping.c
@@ -369,7 +369,8 @@ int main( int argc, char **argv )
 
     if((uid = getuid())) {
         /* drop privileges */
-        setuid( getuid() );
+        if(setuid( getuid() ) == -1)
+            perror("cannot setuid");
     }
 
     prog = argv[0];
@@ -717,6 +718,7 @@ int main( int argc, char **argv )
         if( sent_times_flag ) fprintf( stderr, "  sent_times_flag set\n" );
         if( print_per_system_flag ) fprintf( stderr, "  print_per_system_flag set\n" );
         if( outage_flag ) fprintf( stderr, "  outage_flag set\n" );
+        if( netdata_flag ) fprintf( stderr, "  netdata_flag set\n" );
 
     }/* IF */
 #endif /* DEBUG || _DEBUG */
@@ -1319,7 +1321,7 @@ void print_netdata( void )
         printf("END\n");
 
         if(!sent_charts) {
-            printf("CHART fping.%s_quality '' 'FPing Quality for host %s' percentage '%s' fping.quality line 110010 %d\n", h->name, h->host, h->name, report_interval / 100000);
+            printf("CHART fping.%s_quality '' 'FPing Quality for host %s' percentage '%s' fping.quality area 110010 %d\n", h->name, h->host, h->name, report_interval / 100000);
             printf("DIMENSION returned '' absolute 1 1\n");
             /* printf("DIMENSION lost '' absolute 1 1\n"); */
         }
@@ -1346,7 +1348,7 @@ void print_netdata( void )
         printf("END\n");
 
         if(!sent_charts) {
-            printf("CHART fping.%s_latency '' 'FPing Latency for host %s' ms '%s' fping.latency line 110000 %d\n", h->name, h->host, h->name, report_interval / 100000);
+            printf("CHART fping.%s_latency '' 'FPing Latency for host %s' ms '%s' fping.latency area 110000 %d\n", h->name, h->host, h->name, report_interval / 100000);
             printf("DIMENSION min minimum absolute 10 1000\n");
             printf("DIMENSION max maximum absolute 10 1000\n");
             printf("DIMENSION avg average absolute 10 1000\n");

--- a/src/fping.c
+++ b/src/fping.c
@@ -1101,8 +1101,6 @@ void main_loop()
         /* Make sure we don't wait too long, in case a report is expected */
         if( report_interval && ( loop_flag || count_flag ) ) {
                wait_time_next_report = timeval_diff ( &current_time, &next_report_time );
-               if(wait_time_next_report < 0)
-                    wait_time_next_report = -wait_time_next_report;
                if(wait_time_next_report < wait_time) {
                     wait_time = wait_time_next_report;
                     if(wait_time < 0) { wait_time = 0; }

--- a/src/fping.c
+++ b/src/fping.c
@@ -1101,6 +1101,8 @@ void main_loop()
         /* Make sure we don't wait too long, in case a report is expected */
         if( report_interval && ( loop_flag || count_flag ) ) {
                wait_time_next_report = timeval_diff ( &current_time, &next_report_time );
+               if(wait_time_next_report < 0)
+                    wait_time_next_report = -wait_time_next_report;
                if(wait_time_next_report < wait_time) {
                     wait_time = wait_time_next_report;
                     if(wait_time < 0) { wait_time = 0; }


### PR DESCRIPTION
1. converted netdata charts to `area` charts

    I think charts like this:

     ![image](https://cloud.githubusercontent.com/assets/2662304/19909758/bfb905a8-a091-11e6-9775-17e619b17c1b.png)

    are nicer, than this:

    ![image](https://cloud.githubusercontent.com/assets/2662304/19909785/dda4b116-a091-11e6-9f10-e7ad496905d0.png)

2. added netdata to `trace_flag` output

3. fixed compiler warning about `setuid()` return value being ignored, by calling `perror()` on `setuid()` errors.

4. fix 100% cpu consumption introduced with https://github.com/schweikert/fping/commit/7c7e007502a3a2bd435a9e6b797387dbea8b992c