### PR TITLE
Portability Fixes discovered on Solaris 10, but should be generally applicable

### DIFF
--- a/src/fping.c
+++ b/src/fping.c
@@ -365,6 +365,8 @@ int main( int argc, char **argv )
     int tos = 0; 
     HOST_ENTRY *cursor;
 
+    prog = argv[0];
+
     s = open_ping_socket(ping_data_size);
 
     if((uid = getuid())) {
@@ -373,7 +375,6 @@ int main( int argc, char **argv )
             perror("cannot setuid");
     }
 
-    prog = argv[0];
     ident = getpid() & 0xFFFF;
     verbose_flag = 1;
     backoff_flag = 1;

--- a/src/socket4.c
+++ b/src/socket4.c
@@ -36,6 +36,7 @@
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <netinet/ip.h>
+#include <netinet/in_systm.h>
 #include <netinet/ip_icmp.h>
 #include <netdb.h>
 #include <stdio.h>


### PR DESCRIPTION
David,

These two commits are both trivial and hopefully appropriately explained in the commit messages.

Tested on Solaris 10 Update 8, Solaris 10 Update 11 and Solaris 11.2 with locally built gcc 4.8.5 and gcc 4.9.3 for both 32-bit and 64-bit compiles. I only have access to X86 Solaris Systems (not SPARC).

Regards,
Peter