### PR TITLE
Return -1 when socket_can_read times out.

### DIFF
--- a/src/fping.c
+++ b/src/fping.c
@@ -1716,7 +1716,7 @@ select_again:
 #endif
     }
 
-    return 0;
+    return -1;
 }
 
 int receive_packet(int socket,
@@ -2005,7 +2005,7 @@ int wait_for_reply(long wait_time)
         to.tv_usec = 0;
     }
     s = socket_can_read(&to);
-    if (s == 0) {
+    if (s == -1) {
         return 0; /* timeout */
     }
 


### PR DESCRIPTION
0 is a valid file descriptor. Use -1 instead to signal a timeout. Fixes #125.