### PR TITLE
Fix FreeBSD ipv6 build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -18,6 +18,7 @@ AS_IF([test "x$enable_ipv6" != "xno"], [
     dnl Test if IPv6 is supported
        AC_CHECK_HEADERS([netinet/icmp6.h], [have_ipv6="yes"], [], [[
       #include <netinet/in.h>
+      #include <sys/types.h>
   ]])
 ])
 dnl Can't disable both IPv4 and IPv6


### PR DESCRIPTION
Source: https://svnweb.freebsd.org/ports/head/net/fping/files/patch-configure.ac?revision=473606&view=markup
Fix build fping with ipv6 support on FreeBSD