### PR TITLE
Fix build with --disable-ipv6

### DIFF
--- a/src/fping.c
+++ b/src/fping.c
@@ -687,7 +687,11 @@ int main(int argc, char** argv)
 
     /* validate various option settings */
 
-    if (socket4 < 0 && socket6 < 0) {
+    if (socket4 < 0
+#ifdef IPV6
+	&& socket6 < 0
+#endif
+    ) {
         crash_and_burn("can't create socket (must run as root?)");
     }
 


### PR DESCRIPTION
Otheriwse build breaks with:

fping.c:690:24: error: ‘socket6’ undeclared (first use in this function);
did you mean ‘socket4’?