### PR TITLE
Move to 1us resolution for latency measurements

### DIFF
--- a/ci/test-05-options-c-e.pl
+++ b/ci/test-05-options-c-e.pl
@@ -41,8 +41,8 @@ $cmd->stderr_like(qr{localhost : \d\.\d+ \d\.\d+
 {
 my $cmd = Test::Command->new(cmd => "fping -D -c 2 -p 100 127.0.0.1");
 $cmd->exit_is_num(0);
-$cmd->stdout_like(qr{\[\d{10}\.\d+\] 127\.0\.0\.1 : \[0\], 84 bytes, \d\.\d+ ms \(\d\.\d+ avg, 0% loss\)
-\[\d{10}\.\d+\] 127\.0\.0\.1 : \[1\], 84 bytes, \d\.\d+ ms \(\d\.\d+ avg, 0% loss\)
+$cmd->stdout_like(qr{\[\d+\.\d+\] 127\.0\.0\.1 : \[0\], 84 bytes, \d\.\d+ ms \(\d\.\d+ avg, 0% loss\)
+\[\d+\.\d+\] 127\.0\.0\.1 : \[1\], 84 bytes, \d\.\d+ ms \(\d\.\d+ avg, 0% loss\)
 });
 
 $cmd->stderr_like(qr{127\.0\.0\.1 : xmt/rcv/%loss = 2/2/0%, min/avg/max = \d\.\d+/\d\.\d+/\d\.\d+

--- a/ci/test-15-netdata.pl
+++ b/ci/test-15-netdata.pl
@@ -22,13 +22,13 @@ BEGIN fping\.127_0_0_1_quality
 SET returned = 100
 END
 CHART fping\.127_0_0_1_latency '' 'FPing Latency for host 127\.0\.0\.1' ms '127_0_0_1' fping\.latency area 110000 1
-DIMENSION min minimum absolute 10 1000
-DIMENSION max maximum absolute 10 1000
-DIMENSION avg average absolute 10 1000
+DIMENSION min minimum absolute 1 1000000
+DIMENSION max maximum absolute 1 1000000
+DIMENSION avg average absolute 1 1000000
 BEGIN fping\.127_0_0_1_latency
-SET min = \d{1,2}
-SET avg = \d{1,2}
-SET max = \d{1,2}
+SET min = \d+
+SET avg = \d+
+SET max = \d+
 END}
 );
 $cmd->stderr_like(qr{127.0.0.1 : xmt/rcv/%loss = 2/2/0%, min/avg/max = \d\.\d+/\d\.\d+/\d\.\d+});

--- a/configure.ac
+++ b/configure.ac
@@ -34,9 +34,9 @@ AM_CONDITIONAL([IPV6], [test "x$have_ipv6" = "xyes"])
 AM_COND_IF([IPV6], [AC_DEFINE([IPV6], [1], [IPv6 enabled])])
 
 AC_ARG_ENABLE([timestamp],
-  AS_HELP_STRING([--disable-timestamp], [Disable kernel-based packet timestaping (SO_TIMESTAMP)]))
+  AS_HELP_STRING([--disable-timestamp], [Disable kernel-based packet timestaping (SO_TIMESTAMPNS)]))
 AS_IF([test "x$enable_timestamp" != "xno"], [
-   AC_CHECK_DECL([SO_TIMESTAMP], [AC_DEFINE(HAVE_SO_TIMESTAMP, [1], [SO_TIMESTAMP is defined])], [have_so_timestamp="no"], [#include <sys/types.h>
+   AC_CHECK_DECL([SO_TIMESTAMPNS], [AC_DEFINE(HAVE_SO_TIMESTAMPNS, [1], [SO_TIMESTAMPNS is defined])], [have_so_timestamp="no"], [#include <sys/types.h>
 #include <sys/socket.h>])
 ])
 dnl Test if --enable-timestamp is explicitely enabled and make an error if this platform doesn't support it

--- a/src/fping.c
+++ b/src/fping.c
@@ -437,6 +437,9 @@ int main(int argc, char** argv)
         { "unreach", 'u', OPTPARSE_NONE },
         { "version", 'v', OPTPARSE_NONE },
         { "reachable", 'x', OPTPARSE_REQUIRED },
+#if defined(DEBUG) || defined(_DEBUG)
+        { NULL, 'z', OPTPARSE_REQUIRED },
+#endif
         { 0, 0, 0 }
     };
 

--- a/src/fping.c
+++ b/src/fping.c
@@ -635,8 +635,9 @@ int main(int argc, char** argv)
 
 #if defined(DEBUG) || defined(_DEBUG)
         case 'z':
-            if (!(debugging = (unsigned int)atoi(optparse_state.optarg)))
-                usage(1);
+            if (sscanf(optparse_state.optarg, "0x%x", &debugging) != 1)
+                if (sscanf(optparse_state.optarg, "%u", &debugging) != 1)
+                    usage(1);
 
             break;
 #endif /* DEBUG || _DEBUG */

--- a/src/seqmap.c
+++ b/src/seqmap.c
@@ -66,7 +66,7 @@ void seqmap_init()
     }
 }
 
-unsigned int seqmap_add(unsigned int host_nr, unsigned int ping_count, struct timeval* now)
+unsigned int seqmap_add(unsigned int host_nr, unsigned int ping_count, struct timespec* now)
 {
     unsigned int current_id;
     SEQMAP_VALUE* next_value;
@@ -89,7 +89,7 @@ unsigned int seqmap_add(unsigned int host_nr, unsigned int ping_count, struct ti
     next_value->host_nr = host_nr;
     next_value->ping_count = ping_count;
     next_value->ping_ts.tv_sec = now->tv_sec;
-    next_value->ping_ts.tv_usec = now->tv_usec;
+    next_value->ping_ts.tv_nsec = now->tv_nsec;
 
     /* increase next id */
     current_id = seqmap_next_id;
@@ -98,7 +98,7 @@ unsigned int seqmap_add(unsigned int host_nr, unsigned int ping_count, struct ti
     return current_id;
 }
 
-SEQMAP_VALUE* seqmap_fetch(unsigned int id, struct timeval* now)
+SEQMAP_VALUE* seqmap_fetch(unsigned int id, struct timespec* now)
 {
     SEQMAP_VALUE* value;
 

--- a/src/seqmap.h
+++ b/src/seqmap.h
@@ -7,14 +7,14 @@ typedef struct seqmap_value
 {
     unsigned int    host_nr;
     unsigned int    ping_count;
-    struct timeval  ping_ts;
+    struct timespec ping_ts;
 
 } SEQMAP_VALUE;
 
 #define SEQMAP_MAXSEQ 65535
 
 void seqmap_init();
-unsigned int seqmap_add(unsigned int host_nr, unsigned int ping_count, struct timeval *now);
-SEQMAP_VALUE *seqmap_fetch(unsigned int id, struct timeval *now);
+unsigned int seqmap_add(unsigned int host_nr, unsigned int ping_count, struct timespec *now);
+SEQMAP_VALUE *seqmap_fetch(unsigned int id, struct timespec *now);
 
 #endif


### PR DESCRIPTION
A few fixes:

- The `-z` debug flag was implemented but not accepted by getopt_long. I added it.
- The `-z` debug flag only accepted a decimal argument, and since the argument is a bitfield, I made it possible to take a hex argument, i.e. `0xffff` enables all debug bits.

And the most important part:

- Use 1us resolution for latency measurements. This fixes #101.