### PR TITLE
README.md improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,22 +22,23 @@ _Mailing-list_:
 
 If you want to install fping from source, proceed as follows:
 
-0. Run ./autogen.sh
+0. Run `./autogen.sh`
    (only if you got the source from github)
-1. Run ./configure with the correct arguments
-   (see: ./configure --help)
-2. Run make; make install
+1. Run `./configure` with the correct arguments
+   (see: `./configure --help`)
+2. Run `make; make install`
 3. Make fping either setuid, or, if under Linux:
-   sudo setcap cap_net_raw+ep fping
-4. Have a look at the fping(8) manual for usage help
-   (fping -h will also give a minimal help output)
+   `sudo setcap cap_net_raw+ep fping`
+4. Have a look at the [fping(8)](doc/fping.pod) manual for usage help
+   (`fping -h` will also give a minimal help output)
 
 ## Usage
 
 See: [fping man-page](doc/fping.pod)
 
 ## Credits
-Original author:  Roland Schemers (schemers@stanford.edu)
-Previous maintainer:  RL "Bob" Morgan (morgan@stanford.edu)
-Initial IPv6 Support: Jeroen Massar (jeroen@unfix.org / jeroen@ipng.nl)
-Other contributors: see ChangeLog
+
+* Original author:  Roland Schemers (schemers@stanford.edu)
+* Previous maintainer:  RL "Bob" Morgan (morgan@stanford.edu)
+* Initial IPv6 Support: Jeroen Massar (jeroen@unfix.org / jeroen@ipng.nl)
+* Other contributors: see [ChangeLog](ChangeLog)

--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ _Mailing-list_:
 If you want to install fping from source, proceed as follows:
 
 0. Run `./autogen.sh`
-   (only if you got the source from github)
-1. Run `./configure` with the correct arguments
+   (only if you got the source from Github).
+1. Run `./configure` with the correct arguments.
    (see: `./configure --help`)
-2. Run `make; make install`
+2. Run `make; make install`.
 3. Make fping either setuid, or, if under Linux:
    `sudo setcap cap_net_raw+ep fping`
 4. Have a look at the [fping(8)](doc/fping.pod) manual for usage help

--- a/README.md
+++ b/README.md
@@ -29,12 +29,11 @@ If you want to install fping from source, proceed as follows:
 2. Run `make; make install`.
 3. Make fping either setuid, or, if under Linux:
    `sudo setcap cap_net_raw+ep fping`
-4. Have a look at the [fping(8)](doc/fping.pod) manual for usage help
-   (`fping -h` will also give a minimal help output)
 
 ## Usage
 
-See: [fping man-page](doc/fping.pod)
+Have a look at the [fping(8)](doc/fping.pod) manual page for usage help.
+(`fping -h` will also give a minimal help output.)
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ _Current maintainer_:
   David Schweikert \<david@schweikert.ch\>
 
 _Website_:  
-  http://fping.org/
+  https://fping.org/
 
 _Mailing-list_:  
   https://groups.google.com/group/fping-users


### PR DESCRIPTION
Several `README.md` improvements:

* Use HTTPS for link to fping homepage.
* Use code-style formatting for commandline commands.
* Make the CREDITS list a bulleted list so that there a line breaks between the contributors. (Makes it much more readable.)
* Hyperlink to the Changelog file.
* Add some missing full stops.
* Capitalize "github".
* Merge the two redundant mentions of the man page

See https://github.com/xtaran/fping/tree/develop#readme fow how it looks.