### PR TITLE
Corrected long option name of -s to --stats

### DIFF
--- a/doc/fping.pod
+++ b/doc/fping.pod
@@ -189,7 +189,7 @@ a target will be made, not including the first try.
 Instead of using all-zeros as the packet data, generate random bytes.
 Use to defeat, e.g., link data compression.
 
-=item B<-s>, B<--src>
+=item B<-s>, B<--stats>
 
 Print cumulative statistics upon exit.
 


### PR DESCRIPTION
The option --src is an alias for the uppercase -S.

Stumbled upon this in the man page.

When running "fping -h", the option is printed correctly:
$ -s, --stats        print final stats