### PR TITLE
Do not fail if using fping6 with -6 flag

### DIFF
--- a/src/fping.c
+++ b/src/fping.c
@@ -435,7 +435,7 @@ int main(int argc, char** argv)
             break;
         case '6':
 #ifdef IPV6
-            if (hints_ai_family != AF_UNSPEC) {
+            if (hints_ai_family != AF_UNSPEC && hints_ai_family != AF_INET6) {
                 fprintf(stderr, "%s: can't specify both -4 and -6\n", prog);
                 exit(1);
             }


### PR DESCRIPTION
Proper fix is for user to abandon fping6 but at least this makes it work.

See #147 for discussion and more details.