### PR TITLE
Fix -4 option when IPv6 disabled

### DIFF
--- a/src/fping.c
+++ b/src/fping.c
@@ -427,11 +427,13 @@ int main(int argc, char** argv)
     while ((c = optparse_long(&optparse_state, longopts, NULL)) != EOF) {
         switch (c) {
         case '4':
+#ifdef IPV6
             if (hints_ai_family != AF_UNSPEC) {
                 fprintf(stderr, "%s: can't specify both -4 and -6\n", prog);
                 exit(1);
             }
             hints_ai_family = AF_INET;
+#endif
             break;
         case '6':
 #ifdef IPV6


### PR DESCRIPTION
When IPv6 is disabled, hints_ai_family is set to AF_INET at initialization, resulting in the error "can't specify both -4 and -6" if the -4 option is supplied. If there's no IPv6, make the -4 option a no-op.