### PR TITLE
Do not count packets that are still within their timeout window in packet loss calculation.

### DIFF
--- a/src/fping.c
+++ b/src/fping.c
@@ -2250,8 +2250,8 @@ int wait_for_reply(long wait_time)
             }
 #endif
         }
-        if ( expected < 0 )
-                expected = 0;
+        if ( expected < 1 )
+                expected = 1;
 
         if (h->num_recv <= expected) {
             printf("%d%% loss)",
@@ -2423,7 +2423,10 @@ void add_addr(char* name, char* host, struct sockaddr* ipaddr, socklen_t ipaddr_
     p->timeout = timeout;
     p->running = 1;
     p->min_reply = 0;
+
     p->window_size = 2 * timeout / perhost_interval;
+    if ( p->window_size <= 0 )
+        p->window_size = 1;
 
     if (netdata_flag) {
         char* s = p->name;

--- a/src/fping.c
+++ b/src/fping.c
@@ -2227,34 +2227,35 @@ int wait_for_reply(long wait_time)
         printf(" (%s avg, ", sprint_tm(avg));
 
         /* Calculate the expected number of packets */
-        long now = timeval_diff(&current_time, &start_time);
+        long now = timeval_diff(&recv_time, &start_time);
         int expected = h->num_sent;
         for (int j = 0; j < h->window_size; j++) {
             int v = h->window[j];
+            if ( v >= 0 && h->window[j] + h->timeout > now ){
+               /* This entry has not been received yet */
+               /* And it is still within it's timeout, do not count it*/
+               expected--;
+            }
+#if 0
             if ( v == INT_MIN ){
-                /* This entry has been received */
                 fprintf(stderr, " ");
             }
             else {
-                /* This entry has not been received yet */
                 if (h->window[j] + h->timeout > now ){
-                    /* And it is still within it's timeout, do not count it*/
-                    expected--;
                     fprintf(stderr, ".");
                 }
                 else {
-                    /* It has timed out */
                     fprintf(stderr, "x");
                 }
             }
+#endif
         }
-        fprintf(stderr, " ");
         if ( expected < 0 )
                 expected = 0;
 
         if (h->num_recv <= expected) {
-            printf("%d%% loss %d/%d/%d)",
-                ((expected - h->num_recv) * 100) / expected, h->num_recv, expected, h->num_sent);
+            printf("%d%% loss)",
+                ((expected - h->num_recv) * 100) / expected);
         }
         else {
             printf("%d%% return)",

--- a/src/fping.c
+++ b/src/fping.c
@@ -2252,7 +2252,7 @@ int wait_for_reply(long wait_time)
         if ( expected < 0 )
                 expected = 0;
 
-        if (h->num_recv <= h->num_sent) {
+        if (h->num_recv <= expected) {
             printf("%d%% loss %d/%d/%d)",
                 ((expected - h->num_recv) * 100) / expected, h->num_recv, expected, h->num_sent);
         }


### PR DESCRIPTION
Fix for issue #156 .

Adds a circular buffer of ping sent times `int *window` of length at least ceil(timeout/period). Entries are set to the send time when the ping is sent, and cleared (set to int_min) when a response is received.

During the per-receive stats print out `www.csh.rit.edu : [3], 228 bytes, 77.4 ms (77.5 avg, 42% loss)` these sent times are compared to the current time + the timeout. Any requests that are still unanswered, but within their timeout window, are excluded from the packet loss calculation.

Please excuse all the extra `fprintf`s, I will clean out my debugging output as I finalize this PR, if you indicate that it might be accepted.

Thank you!