### PR TITLE
Fix xmt stats in Netdata output

### DIFF
--- a/src/fping.c
+++ b/src/fping.c
@@ -1469,6 +1469,15 @@ void print_netdata(void)
     for (i = 0; i < num_hosts; i++) {
         h = table[i];
 
+        /* if we just sent the probe and didn't receive a reply, we shouldn't count it */
+        h->discard_next_recv_i = 0;
+        if (h->waiting && timeval_diff(&current_time, &h->last_send_time) < h->timeout) {
+            if (h->num_sent_i) {
+                h->num_sent_i--;
+                h->discard_next_recv_i = 1;
+            }
+        }
+
         if (!sent_charts) {
             printf("CHART fping.%s_packets '' 'FPing Packets for host %s' packets '%s' fping.packets line 110020 %d\n", h->name, h->host, h->name, report_interval / 100000);
             printf("DIMENSION xmt sent absolute 1 1\n");
@@ -1484,15 +1493,6 @@ void print_netdata(void)
             printf("CHART fping.%s_quality '' 'FPing Quality for host %s' percentage '%s' fping.quality area 110010 %d\n", h->name, h->host, h->name, report_interval / 100000);
             printf("DIMENSION returned '' absolute 1 1\n");
             /* printf("DIMENSION lost '' absolute 1 1\n"); */
-        }
-
-        /* if we just sent the probe and didn't receive a reply, we shouldn't count it */
-        h->discard_next_recv_i = 0;
-        if (h->waiting && timeval_diff(&current_time, &h->last_send_time) < h->timeout) {
-            if (h->num_sent_i) {
-                h->num_sent_i--;
-                h->discard_next_recv_i = 1;
-            }
         }
 
         printf("BEGIN fping.%s_quality\n", h->name);


### PR DESCRIPTION
There was a difference in stats for received/transmitted packets when the Netdata protocol was used.
```
BEGIN fping.google_com_packets
SET xmt = 5
SET rcv = 5
END
BEGIN fping.google_com_quality
SET returned = 100
END
BEGIN fping.google_com_latency
SET min = 2793
SET avg = 2798
SET max = 2801
END
BEGIN fping.google_com_packets
SET xmt = 5
SET rcv = 4
END
BEGIN fping.google_com_quality
SET returned = 100
END
BEGIN fping.google_com_latency
SET min = 2781
SET avg = 2787
SET max = 2794
END
...
BEGIN fping.google_com_packets
SET xmt = 5
SET rcv = 4
END
BEGIN fping.google_com_quality
SET returned = 100
END
BEGIN fping.google_com_latency
SET min = 2789
SET avg = 2794
SET max = 2800
END
BEGIN fping.google_com_packets
SET xmt = 4
SET rcv = 4
END
BEGIN fping.google_com_quality
SET returned = 100
END
BEGIN fping.google_com_latency
SET min = 2790
SET avg = 2794
SET max = 2804
END
BEGIN fping.google_com_packets
SET xmt = 5
SET rcv = 5
END
BEGIN fping.google_com_quality
SET returned = 100
END
BEGIN fping.google_com_latency
SET min = 2786
SET avg = 2795
SET max = 2803
END
```
The correction for `num_sent_i` was moved to the appropriate place. The output for Netdata is sane now.
```
BEGIN fping.google_com_packets
SET xmt = 4
SET rcv = 4
END
```