### PR TITLE
Linux unprivileged ping support

### DIFF
--- a/ci/test-11-nopriv.pl
+++ b/ci/test-11-nopriv.pl
@@ -1,5 +1,6 @@
 #!/usr/bin/perl -w
 
+use English;
 use Test::Command;
 use Test::More;
 
@@ -7,6 +8,26 @@ if( $^O eq 'darwin' ) {
     plan skip_all => 'Test irrelevant on MacOS';
     exit 0;
 }
+
+sub get_ping_gid_range {
+	open FD, "/proc/sys/net/ipv4/ping_group_range" or return undef;
+	chomp(my $line = <FD>);
+	my @range = split(/\s+/, $line);
+	close FD;
+	return @range;
+}
+
+my @gids = split(' ', $EGID);
+my @allowed_gid_range = get_ping_gid_range();
+
+# Linux test for unprivileged ping support
+foreach(@gids) {
+	if ($_ >= $allowed_gid_range[0] && $_ <= $allowed_gid_range[1]) {
+		plan skip_all => "Userspace pings are allowed, gid $_ in range [$allowed_gid_range[0], $allowed_gid_range[1]]";
+		exit 0;
+	}
+}
+
 plan tests => 3;
 
 # run without privileges

--- a/src/fping.c
+++ b/src/fping.c
@@ -230,11 +230,12 @@ HOST_ENTRY* ev_first;
 HOST_ENTRY* ev_last;
 
 char* prog;
-int ident; /* our pid */
+int ident4 = 0; /* our icmp identity field */
 int socket4 = -1;
 #ifndef IPV6
 int hints_ai_family = AF_INET;
 #else
+int ident6 = 0;
 int socket6 = -1;
 int hints_ai_family = AF_UNSPEC;
 #endif
@@ -368,6 +369,11 @@ int main(int argc, char** argv)
     }
 #endif
 
+    memset(&src_addr, 0, sizeof(src_addr));
+#ifdef IPV6
+    memset(&src_addr6, 0, sizeof(src_addr6));
+#endif
+
     if ((uid = getuid())) {
         /* drop privileges */
         if (setuid(getuid()) == -1)
@@ -375,7 +381,7 @@ int main(int argc, char** argv)
     }
 
     optparse_init(&optparse_state, argv);
-    ident = getpid() & 0xFFFF;
+    ident4 = ident6 = getpid() & 0xFFFF;
     verbose_flag = 1;
     backoff_flag = 1;
     opterr = 1;
@@ -965,12 +971,12 @@ int main(int argc, char** argv)
         exit(num_noaddress ? 2 : 1);
     }
 
-    if (src_addr_set && socket4 >= 0) {
-        socket_set_src_addr_ipv4(socket4, &src_addr);
+    if (socket4 >= 0) {
+        socket_set_src_addr_ipv4(socket4, &src_addr, &ident4);
     }
 #ifdef IPV6
-    if (src_addr6_set && socket6 >= 0) {
-        socket_set_src_addr_ipv6(socket6, &src_addr6);
+    if (socket6 >= 0) {
+        socket_set_src_addr_ipv6(socket6, &src_addr6, &ident6);
     }
 #endif
 
@@ -1674,11 +1680,11 @@ int send_ping(HOST_ENTRY* h)
 #endif /* DEBUG || _DEBUG */
 
     if (h->saddr.ss_family == AF_INET && socket4 >= 0) {
-        n = socket_sendto_ping_ipv4(socket4, (struct sockaddr*)&h->saddr, h->saddr_len, myseq, ident);
+        n = socket_sendto_ping_ipv4(socket4, (struct sockaddr*)&h->saddr, h->saddr_len, myseq, ident4);
     }
 #ifdef IPV6
     else if (h->saddr.ss_family == AF_INET6 && socket6 >= 0) {
-        n = socket_sendto_ping_ipv6(socket6, (struct sockaddr*)&h->saddr, h->saddr_len, myseq, ident);
+        n = socket_sendto_ping_ipv6(socket6, (struct sockaddr*)&h->saddr, h->saddr_len, myseq, ident6);
     }
 #endif
     else {
@@ -1871,7 +1877,7 @@ int decode_icmp_ipv4(
 
         sent_icmp = (struct icmp*)(reply_buf + hlen + ICMP_MINLEN + sizeof(struct ip));
 
-        if (sent_icmp->icmp_type != ICMP_ECHO || ntohs(sent_icmp->icmp_id) != ident) {
+        if (sent_icmp->icmp_type != ICMP_ECHO || sent_icmp->icmp_id != ident4) {
             /* not caused by us */
             return 0;
         }
@@ -1920,7 +1926,7 @@ int decode_icmp_ipv4(
         return 0;
     }
 
-    *id = ntohs(icp->icmp_id);
+    *id = icp->icmp_id;
     *seq = ntohs(icp->icmp_seq);
 
     return 1;
@@ -1963,7 +1969,7 @@ int decode_icmp_ipv6(
 
         sent_icmp = (struct icmp6_hdr*)(reply_buf + sizeof(struct icmp6_hdr) + sizeof(struct ip));
 
-        if (sent_icmp->icmp6_type != ICMP_ECHO || ntohs(sent_icmp->icmp6_id) != ident) {
+        if (sent_icmp->icmp6_type != ICMP_ECHO || sent_icmp->icmp6_id != ident6) {
             /* not caused by us */
             return 0;
         }
@@ -2012,7 +2018,7 @@ int decode_icmp_ipv6(
         return 0;
     }
 
-    *id = ntohs(icp->icmp6_id);
+    *id = icp->icmp6_id;
     *seq = ntohs(icp->icmp6_seq);
 
     return 1;
@@ -2082,6 +2088,9 @@ int wait_for_reply(long wait_time)
                 &seq)) {
             return 1;
         }
+        if (id != ident4) {
+            return 1; /* packet received, but not the one we are looking for! */
+        }
     }
 #ifdef IPV6
     else if (response_addr.ss_family == AF_INET6) {
@@ -2094,14 +2103,13 @@ int wait_for_reply(long wait_time)
                 &seq)) {
             return 1;
         }
+        if (id != ident6) {
+            return 1; /* packet received, but not the one we are looking for! */
+        }
     }
 #endif
     else {
         return 1;
-    }
-
-    if (id != ident) {
-        return 1; /* packet received, but not the one we are looking for! */
     }
 
     seqmap_value = seqmap_fetch(seq, &current_time);

--- a/src/fping.h
+++ b/src/fping.h
@@ -14,7 +14,7 @@ int in_cksum( unsigned short *p, int n );
 extern int random_data_flag;
 
 /* socket.c */
-int  open_ping_socket_ipv4();
+int  open_ping_socket_ipv4(int *using_sock_dgram);
 void init_ping_buffer_ipv4(size_t ping_data_size);
 void socket_set_src_addr_ipv4(int s, struct in_addr *src_addr, int *ident);
 int  socket_sendto_ping_ipv4(int s, struct sockaddr *saddr, socklen_t saddr_len, uint16_t icmp_seq, uint16_t icmp_id);

--- a/src/fping.h
+++ b/src/fping.h
@@ -16,12 +16,12 @@ extern int random_data_flag;
 /* socket.c */
 int  open_ping_socket_ipv4();
 void init_ping_buffer_ipv4(size_t ping_data_size);
-void socket_set_src_addr_ipv4(int s, struct in_addr *src_addr);
+void socket_set_src_addr_ipv4(int s, struct in_addr *src_addr, int *ident);
 int  socket_sendto_ping_ipv4(int s, struct sockaddr *saddr, socklen_t saddr_len, uint16_t icmp_seq, uint16_t icmp_id);
 #ifdef IPV6
 int  open_ping_socket_ipv6();
 void init_ping_buffer_ipv6(size_t ping_data_size);
-void socket_set_src_addr_ipv6(int s, struct in6_addr *src_addr);
+void socket_set_src_addr_ipv6(int s, struct in6_addr *src_addr, int *ident);
 int  socket_sendto_ping_ipv6(int s, struct sockaddr *saddr, socklen_t saddr_len, uint16_t icmp_seq, uint16_t icmp_id);
 #endif
 

--- a/src/socket4.c
+++ b/src/socket4.c
@@ -89,15 +89,23 @@ void init_ping_buffer_ipv4(size_t ping_data_size)
         crash_and_burn("can't malloc ping packet");
 }
 
-void socket_set_src_addr_ipv4(int s, struct in_addr* src_addr)
+void socket_set_src_addr_ipv4(int s, struct in_addr* src_addr, int *ident)
 {
     struct sockaddr_in sa;
-    memset(&sa, 0, sizeof(sa));
+    socklen_t len = sizeof(sa);
+
+    memset(&sa, 0, len);
     sa.sin_family = AF_INET;
     sa.sin_addr = *src_addr;
-
-    if (bind(s, (struct sockaddr*)&sa, sizeof(sa)) < 0)
+    if (bind(s, (struct sockaddr*)&sa, len) < 0)
         errno_crash_and_burn("cannot bind source address");
+
+    memset(&sa, 0, len);
+    if (getsockname(s, (struct sockaddr *)&sa, &len) < 0)
+        errno_crash_and_burn("can't get ICMP socket identity");
+
+    if (sa.sin_port)
+        *ident = sa.sin_port;
 }
 
 unsigned short calcsum(unsigned short* buffer, int length)
@@ -128,7 +136,7 @@ int socket_sendto_ping_ipv4(int s, struct sockaddr* saddr, socklen_t saddr_len, 
     icp->icmp_code = 0;
     icp->icmp_cksum = 0;
     icp->icmp_seq = htons(icmp_seq_nr);
-    icp->icmp_id = htons(icmp_id_nr);
+    icp->icmp_id = icmp_id_nr;
 
     if (random_data_flag) {
         for (n = ((char*)&icp->icmp_data - (char*)icp); n < ping_pkt_size_ipv4; ++n) {


### PR DESCRIPTION
Right now if you try to use unprivileged ping (i.e. via `SOCK_DGRAM`) on the "develop" branch, it doesn't see the response packets.

There are a few problems this PR fixes:
- The "ident" value cannot be specified by unprivileged processes, so we have to get it from the kernel via `getsockname`. This change is necessary in order for it to see the ident fields line up and accept the responses.
- When using `SOCK_DGRAM` for IPv4 unprivileged ping on Linux, there is no `struct ip` at the beginning of the message read by `recvmsg`. So we have to handle that situation specially. First, we need to account for the size of the missing header when logging the responses (since it *is* data sent/received over the wire, but it's not visible to the userspace process). Second, we need to avoid treating the start of the buffer as `struct ip`.
- The `test-11-nopriv` test will fail on Linux if the user is allowed to do unprivileged pings. We can check if the effective GID is within the range specified in the sysctl `net.ipv4.ping_group_range` and know in advance whether the ping is expected to work or not. If it is expected to work, then we should skip the `test-11-nopriv` test.