### PR TITLE
Add SIGQUIT summary support similar to ping

### DIFF
--- a/ci/test-07-options-i-m.pl
+++ b/ci/test-07-options-i-m.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 
-use Test::Command tests => 7;
+use Test::Command tests => 9;
 use Test::More;
 
 #  -i n       interval between sending ping packets (in millisec) (default 25)
@@ -23,6 +23,21 @@ $cmd->stdout_like(qr{127\.0\.0\.1 : \[0\], 84 bytes, \d\.\d+ ms \(\d\.\d+ avg, 0
 127\.0\.0\.1 : \[1\], 84 bytes, \d\.\d+ ms \(\d\.\d+ avg, 0% loss\)
 });
 }
+
+# fping -l with SIGQUIT
+{
+my $cmd = Test::Command->new(cmd => '(sleep 2; pkill -QUIT fping; sleep 2; pkill fping)& fping -p 900 -l 127.0.0.1');
+$cmd->stdout_like(qr{127\.0\.0\.1 : \[0\], 84 bytes, \d\.\d+ ms \(\d\.\d+ avg, 0% loss\)
+127\.0\.0\.1 : \[1\], 84 bytes, \d\.\d+ ms \(\d\.\d+ avg, 0% loss\)
+127\.0\.0\.1 : \[2\], 84 bytes, \d\.\d+ ms \(\d\.\d+ avg, 0% loss\)
+127\.0\.0\.1 : \[3\], 84 bytes, \d\.\d+ ms \(\d\.\d+ avg, 0% loss\)
+127\.0\.0\.1 : \[4\], 84 bytes, \d\.\d+ ms \(\d\.\d+ avg, 0% loss\)
+});
+$cmd->stderr_like(qr{\[\d+:\d+:\d+\]
+127\.0\.0\.1 : xmt/rcv/%loss = \d+/\d+/\d+%, min/avg/max = \d+\.\d+/\d+\.\d+/\d+\.\d+
+});
+}
+
 
 # fping -M
 SKIP: {

--- a/doc/fping.pod
+++ b/doc/fping.pod
@@ -19,7 +19,8 @@ of targets to check; if a target does not respond within a certain time limit
 and/or retry limit it is designated as unreachable. B<fping> also supports
 sending a specified number of pings to a target, or looping indefinitely (as in
 B<ping> ). Unlike B<ping>, B<fping> is meant to be used in scripts, so its
-output is designed to be easy to parse.
+output is designed to be easy to parse.  Current statistics can be obtained without
+termination of process with signal SIGQUIT (^\ from the keyboard on most systems).
 
 =head1 OPTIONS
 


### PR DESCRIPTION
ping supports printing out an intermediate summary of results and resuming via `SIGQUIT` (`ctrl-\`). fping currently prints out summary statistics only for hosts responding.  This allows a summary to be output of all hosts without terminating the run.

Sample output:
```
fping -g 192.168.42.210 192.168.42.212 -l
192.168.42.211 : [0], 84 bytes, 1.00 ms (1.00 avg, 0% loss)
192.168.42.211 : [1], 84 bytes, 2.40 ms (1.70 avg, 0% loss)
192.168.42.211 : [2], 84 bytes, 0.93 ms (1.44 avg, 0% loss)
192.168.42.211 : [3], 84 bytes, 1.31 ms (1.41 avg, 0% loss)
ICMP Host Unreachable from 192.168.42.150 for ICMP Echo sent to 192.168.42.212
ICMP Host Unreachable from 192.168.42.150 for ICMP Echo sent to 192.168.42.212
ICMP Host Unreachable from 192.168.42.150 for ICMP Echo sent to 192.168.42.212
ICMP Host Unreachable from 192.168.42.150 for ICMP Echo sent to 192.168.42.212
ICMP Host Unreachable from 192.168.42.150 for ICMP Echo sent to 192.168.42.210
ICMP Host Unreachable from 192.168.42.150 for ICMP Echo sent to 192.168.42.210
ICMP Host Unreachable from 192.168.42.150 for ICMP Echo sent to 192.168.42.210
ICMP Host Unreachable from 192.168.42.150 for ICMP Echo sent to 192.168.42.210
192.168.42.211 : [4], 84 bytes, 1.03 ms (1.33 avg, 0% loss)
^\
[18:56:16]
192.168.42.210 : xmt/rcv/%loss = 5/0/100%
192.168.42.211 : xmt/rcv/%loss = 5/5/0%, min/avg/max = 0.93/1.33/2.40
192.168.42.212 : xmt/rcv/%loss = 4/0/100%
192.168.42.211 : [5], 84 bytes, 1.12 ms (1.29 avg, 0% loss)
^C
192.168.42.210 : xmt/rcv/%loss = 6/0/100%
192.168.42.211 : xmt/rcv/%loss = 6/6/0%, min/avg/max = 0.93/1.29/2.40
192.168.42.212 : xmt/rcv/%loss = 6/0/100%
```