### PR TITLE
Fix build with --disable-ipv6

### DIFF
--- a/src/fping.c
+++ b/src/fping.c
@@ -258,12 +258,12 @@ HOST_ENTRY* ev_last;
 
 char* prog;
 int ident4 = 0; /* our icmp identity field */
+int ident6 = 0;
 int socket4 = -1;
 int using_sock_dgram4 = 0;
 #ifndef IPV6
 int hints_ai_family = AF_INET;
 #else
-int ident6 = 0;
 int socket6 = -1;
 int hints_ai_family = AF_UNSPEC;
 #endif


### PR DESCRIPTION
Otherwise build breaks with:
```
fping.c:399:14: error: ‘ident6’ undeclared (first use in this function); did you mean ‘ident4’?
  399 |     ident4 = ident6 = getpid() & 0xFFFF;
      |              ^~~~~~
      |              ident4
```
Signed-off-by: Lars Wendler <polynomial-c@gentoo.org>