### PR TITLE
Improve portability of signal handling

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -73,6 +73,10 @@ AC_CHECK_FUNC(connect)
 if test $ac_cv_func_connect = no; then
     AC_CHECK_LIB(socket, connect)
 fi
+AC_CHECK_FUNC(sigaction)
+if test $ac_cv_func_sigaction = yes; then
+    AC_DEFINE([USE_SIGACTION],[1],[Define if sigaction is available.])
+fi
 
 AH_TOP([
 #ifndef CONFIG_H


### PR DESCRIPTION
This PR contains two adjustments to make signal handling more portable:

1. Instead of directly calling `finish` on `SIGINT` it sets a flag to signal the loop to terminate.
The `signal` documentation specifies that using `printf` inside of a signal handler can cause issues.
The actual location of the exit might need to be adjusted since I am unfamiliar with the event handling code and when to best check for termination.

2. Use `sigaction` instead of `signal` when available. When using `signal` with any handler other than `SIG_DFL` or `SIG_IGN` the behavior is implementation-defined. On Debian WSL this means the signal handler just does not work. By switching to `sigaction` when that function is available it should work identically on any platform that supports it.
