### PR TITLE
docs: fix simple typo, permanetly -> permanently

### DIFF
--- a/src/fping.c
+++ b/src/fping.c
@@ -832,7 +832,7 @@ int main(int argc, char** argv)
         }
     }
 
-    /* permanetly drop privileges */
+    /* permanently drop privileges */
     if (suid != getuid() && setuid(getuid())) {
 	perror("fatal: failed to permanently drop privileges");
 	/* continuing would be a security hole */


### PR DESCRIPTION
There is a small typo in src/fping.c.

Should read `permanently` rather than `permanetly`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md