### PR TITLE
Allow -4 option to be given multiple times when IPv6 is enabled.

### DIFF
--- a/src/fping.c
+++ b/src/fping.c
@@ -546,7 +546,7 @@ int main(int argc, char** argv)
         switch (c) {
         case '4':
 #ifdef IPV6
-            if (hints_ai_family != AF_UNSPEC) {
+            if (hints_ai_family != AF_UNSPEC && hints_ai_family != AF_INET) {
                 fprintf(stderr, "%s: can't specify both -4 and -6\n", prog);
                 exit(1);
             }


### PR DESCRIPTION
Commit 509f5a59cb717edf3b4ef7fe0fbf6d31f0ed0199 is related but just skipped the check when IPv6 is disabled. This fixes the check for the  `-4` option is the same way that commit 6fd4f8bd91abc43f80078bdd0084cb6d2b1de7f1 did for the `-6` option.