### PR TITLE
use formatstring macro PRId64 in print_netdata for output int64_t

### DIFF
--- a/src/fping.c
+++ b/src/fping.c
@@ -1699,9 +1699,9 @@ void print_netdata(void)
         printf("BEGIN fping.%s_latency\n", h->name);
         if (h->num_recv_i) {
             avg = h->total_time_i / h->num_recv_i;
-            printf("SET min = %ld\n", h->min_reply_i);
-            printf("SET avg = %ld\n", avg);
-            printf("SET max = %ld\n", h->max_reply_i);
+            printf("SET min = %" PRId64 "\n", h->min_reply_i);
+            printf("SET avg = %" PRId64 "\n", avg);
+            printf("SET max = %" PRId64 "\n", h->max_reply_i);
         }
         printf("END\n");
 


### PR DESCRIPTION
On diffrent architecture int64_t is long int or long long int. This change use the format string macro PRId64 from inttypes.h in the print_netdata function to set individually "ld" or "lld" at printf output

Fixes #219