### PR TITLE
Fix getnameinfo() is not called properly for IPv4

### DIFF
--- a/src/fping.c
+++ b/src/fping.c
@@ -2102,7 +2102,7 @@ int decode_icmp_ipv4(
         /* too short */
         if (verbose_flag) {
             char buf[INET6_ADDRSTRLEN];
-            getnameinfo((struct sockaddr*)&response_addr, sizeof(response_addr), buf, INET6_ADDRSTRLEN, NULL, 0, NI_NUMERICHOST);
+            getnameinfo(response_addr, sizeof(struct sockaddr_in), buf, INET6_ADDRSTRLEN, NULL, 0, NI_NUMERICHOST);
             printf("received packet too short for ICMP (%d bytes from %s)\n", (int)reply_buf_len, buf);
         }
         return -1;
@@ -2135,7 +2135,7 @@ int decode_icmp_ipv4(
             return -1;
         }
 
-        getnameinfo(response_addr, response_addr_len, addr_ascii, INET6_ADDRSTRLEN, NULL, 0, NI_NUMERICHOST);
+        getnameinfo(response_addr, sizeof(struct sockaddr_in), addr_ascii, INET6_ADDRSTRLEN, NULL, 0, NI_NUMERICHOST);
 
         switch (icp->icmp_type) {
         case ICMP_UNREACH:


### PR DESCRIPTION
Add Patch #218 from @aafbsd to pull request.