### PR TITLE
Extend timestamp with date

### DIFF
--- a/src/fping.c
+++ b/src/fping.c
@@ -1735,8 +1735,8 @@ void print_per_system_splits(void)
 
     update_current_time();
     curr_tm = localtime((time_t*)&current_time.tv_sec);
-    fprintf(stderr, "[%2.2d:%2.2d:%2.2d]\n", curr_tm->tm_hour,
-        curr_tm->tm_min, curr_tm->tm_sec);
+    fprintf(stderr, "[%2.2d:%2.2d:%2.2d %d.%d.%d]\n", curr_tm->tm_hour, curr_tm->tm_min,
+        curr_tm->tm_sec, curr_tm->tm_mday, curr_tm->tm_mon + 1, curr_tm->tm_year + 1900);
 
     for (i = 0; i < num_hosts; i++) {
         h = table[i];
@@ -1767,6 +1767,8 @@ void print_per_system_splits(void)
         fprintf(stderr, "\n");
         h->num_sent_i = h->num_recv_i = h->max_reply_i = h->min_reply_i = h->total_time_i = 0;
     }
+
+    fprintf(stderr, "\n");
 }
 
 /************************************************************


### PR DESCRIPTION
Print current date in timestamp when -Q option is used.
Extra new line added after each report.
Example output:
[05:47:24 17.12.2021]
ya.ru      : xmt/rcv/%loss = 30/30/0%, min/avg/max = 47.1/47.2/47.2
he.net     : xmt/rcv/%loss = 30/30/0%, min/avg/max = 222/222/223
google.com : xmt/rcv/%loss = 30/30/0%, min/avg/max = 55.0/55.1/55.2

[05:47:54 17.12.2021]
ya.ru      : xmt/rcv/%loss = 30/30/0%, min/avg/max = 47.1/47.2/47.2
he.net     : xmt/rcv/%loss = 30/30/0%, min/avg/max = 222/222/223
google.com : xmt/rcv/%loss = 30/30/0%, min/avg/max = 55.0/55.1/55.2
