### PR TITLE
Documentation improvements

### DIFF
--- a/doc/fping.pod
+++ b/doc/fping.pod
@@ -178,7 +178,8 @@ show ICMP error messages.
 
 =item B<-Q>, B<--squiet>=I<SECS>
 
-Like B<-q>, but show summary results every n seconds.
+Like B<-q>, but additionally show interval summary results every I<SECS>
+seconds.
 
 =item B<-r>, B<--retry>=I<N>
 

--- a/doc/fping.pod
+++ b/doc/fping.pod
@@ -81,7 +81,7 @@ C<-> indicating that no response was received to the fourth request.
 
 =item B<-d>, B<--rdns>
 
-Use DNS to lookup address of return ping packet. This allows you to give fping
+Use DNS to lookup address of ping target. This allows you to give fping
 a list of IP addresses as input and print hostnames in the output. This is similar
 to option B<-n>/B<--name>, but will force a reverse-DNS lookup even if you give
 hostnames as target (NAME->IP->NAME).
@@ -150,7 +150,7 @@ Set the "Don't Fragment" bit in the IP header (used to determine/test the MTU).
 =item B<-n>, B<--name>
 
 If targets are specified as IP addresses, do a reverse-DNS lookup on them
-to
+to print hostnames in the output.
 
 =item B<-N>, B<--netdata>
 

--- a/src/fping.c
+++ b/src/fping.c
@@ -2931,10 +2931,11 @@ void usage(int is_error)
     fprintf(out, "   -a, --alive        show targets that are alive\n");
     fprintf(out, "   -A, --addr         show targets by address\n");
     fprintf(out, "   -C, --vcount=N     same as -c, report results in verbose format\n");
+    fprintf(out, "   -d, --rdns         show targets by name (force reverse-DNS lookup)\n");
     fprintf(out, "   -D, --timestamp    print timestamp before each output line\n");
     fprintf(out, "   -e, --elapsed      show elapsed time on return packets\n");
     fprintf(out, "   -i, --interval=MSEC  interval between sending ping packets (default: %.0f ms)\n", interval / 1e6);
-    fprintf(out, "   -n, --name         show targets by name (-d is equivalent)\n");
+    fprintf(out, "   -n, --name         show targets by name (reverse-DNS lookup for target IPs)\n");
     fprintf(out, "   -N, --netdata      output compatible for netdata (-l -Q are required)\n");
     fprintf(out, "   -o, --outage       show the accumulated outage time (lost packets * packet interval)\n");
     fprintf(out, "   -q, --quiet        quiet (don't show per-target/per-ping results)\n");

--- a/src/fping.c
+++ b/src/fping.c
@@ -2939,7 +2939,7 @@ void usage(int is_error)
     fprintf(out, "   -N, --netdata      output compatible for netdata (-l -Q are required)\n");
     fprintf(out, "   -o, --outage       show the accumulated outage time (lost packets * packet interval)\n");
     fprintf(out, "   -q, --quiet        quiet (don't show per-target/per-ping results)\n");
-    fprintf(out, "   -Q, --squiet=SECS  same as -q, but show summary every n seconds\n");
+    fprintf(out, "   -Q, --squiet=SECS  same as -q, but add interval summary every SECS seconds\n");
     fprintf(out, "   -s, --stats        print final stats\n");
     fprintf(out, "   -u, --unreach      show targets that are unreachable\n");
     fprintf(out, "   -v, --version      show version\n");


### PR DESCRIPTION
Two small improvements to the documentation, i.e., `fping.pod` and `fping -h` output:

1. Adjust documentation for `-d` and `-n` to the implemented behavior.
2. Slightly expand the documentation for `-Q`.