### PR TITLE
Regularly print full instead of interval stats with -Q SECS -F (--squiet=SECS --full)

### DIFF
--- a/ci/test-08-options-n-q.pl
+++ b/ci/test-08-options-n-q.pl
@@ -59,27 +59,27 @@ $cmd->stderr_like(qr{127\.0\.0\.1 : xmt/rcv/%loss = 3/3/0%, min/avg/max = \d\.\d
 
 # fping -Q
 {
-my $cmd = Test::Command->new(cmd => "fping -Q 1 -p 450 -c 6 127.0.0.1");
+my $cmd = Test::Command->new(cmd => "fping -Q 1 -p 550 -c 5 127.0.0.1");
 $cmd->exit_is_num(0);
 $cmd->stdout_is_eq("");
 $cmd->stderr_like(qr{\[\d+:\d+:\d+\]
-127\.0\.0\.1 : xmt/rcv/%loss = 3/3/0%, min/avg/max = \d\.\d+/\d\.\d+/\d\.\d+
+127\.0\.0\.1 : xmt/rcv/%loss = 2/2/0%, min/avg/max = \d\.\d+/\d\.\d+/\d\.\d+
 \[\d+:\d+:\d+\]
 127\.0\.0\.1 : xmt/rcv/%loss = 2/2/0%, min/avg/max = \d\.\d+/\d\.\d+/\d\.\d+
-127\.0\.0\.1 : xmt/rcv/%loss = 6/6/0%, min/avg/max = \d\.\d+/\d\.\d+/\d\.\d+
+127\.0\.0\.1 : xmt/rcv/%loss = 5/5/0%, min/avg/max = \d\.\d+/\d\.\d+/\d\.\d+
 });
 }
 
 # fping -Q -F
 {
-my $cmd = Test::Command->new(cmd => "fping -Q 1 -F -p 450 -c 6 127.0.0.1");
+my $cmd = Test::Command->new(cmd => "fping -Q 1 -F -p 550 -c 5 127.0.0.1");
 $cmd->exit_is_num(0);
 $cmd->stdout_is_eq("");
 $cmd->stderr_like(qr{\[\d+:\d+:\d+\]
-127\.0\.0\.1 : xmt/rcv/%loss = 3/3/0%, min/avg/max = \d\.\d+/\d\.\d+/\d\.\d+
+127\.0\.0\.1 : xmt/rcv/%loss = 2/2/0%, min/avg/max = \d\.\d+/\d\.\d+/\d\.\d+
 \[\d+:\d+:\d+\]
+127\.0\.0\.1 : xmt/rcv/%loss = 4/4/0%, min/avg/max = \d\.\d+/\d\.\d+/\d\.\d+
 127\.0\.0\.1 : xmt/rcv/%loss = 5/5/0%, min/avg/max = \d\.\d+/\d\.\d+/\d\.\d+
-127\.0\.0\.1 : xmt/rcv/%loss = 6/6/0%, min/avg/max = \d\.\d+/\d\.\d+/\d\.\d+
 });
 }
 

--- a/ci/test-08-options-n-q.pl
+++ b/ci/test-08-options-n-q.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 
-use Test::Command tests => 18;
+use Test::Command tests => 21;
 
 #  -n         show targets by name (-d is equivalent)
 #  -O n       set the type of service (tos) flag on the ICMP packets
@@ -59,13 +59,27 @@ $cmd->stderr_like(qr{127\.0\.0\.1 : xmt/rcv/%loss = 3/3/0%, min/avg/max = \d\.\d
 
 # fping -Q
 {
-my $cmd = Test::Command->new(cmd => "fping -Q 1 -p 400 -c 4 127.0.0.1");
+my $cmd = Test::Command->new(cmd => "fping -Q 1 -p 450 -c 6 127.0.0.1");
 $cmd->exit_is_num(0);
 $cmd->stdout_is_eq("");
 $cmd->stderr_like(qr{\[\d+:\d+:\d+\]
 127\.0\.0\.1 : xmt/rcv/%loss = 3/3/0%, min/avg/max = \d\.\d+/\d\.\d+/\d\.\d+
-127\.0\.0\.1 : xmt/rcv/%loss = 4/4/0%, min/avg/max = \d\.\d+/\d\.\d+/\d\.\d+
+\[\d+:\d+:\d+\]
+127\.0\.0\.1 : xmt/rcv/%loss = 2/2/0%, min/avg/max = \d\.\d+/\d\.\d+/\d\.\d+
+127\.0\.0\.1 : xmt/rcv/%loss = 6/6/0%, min/avg/max = \d\.\d+/\d\.\d+/\d\.\d+
 });
 }
 
+# fping -Q -F
+{
+my $cmd = Test::Command->new(cmd => "fping -Q 1 -F -p 450 -c 6 127.0.0.1");
+$cmd->exit_is_num(0);
+$cmd->stdout_is_eq("");
+$cmd->stderr_like(qr{\[\d+:\d+:\d+\]
+127\.0\.0\.1 : xmt/rcv/%loss = 3/3/0%, min/avg/max = \d\.\d+/\d\.\d+/\d\.\d+
+\[\d+:\d+:\d+\]
+127\.0\.0\.1 : xmt/rcv/%loss = 5/5/0%, min/avg/max = \d\.\d+/\d\.\d+/\d\.\d+
+127\.0\.0\.1 : xmt/rcv/%loss = 6/6/0%, min/avg/max = \d\.\d+/\d\.\d+/\d\.\d+
+});
+}
 

--- a/ci/test-08-options-n-q.pl
+++ b/ci/test-08-options-n-q.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 
-use Test::Command tests => 21;
+use Test::Command tests => 27;
 
 #  -n         show targets by name (-d is equivalent)
 #  -O n       set the type of service (tos) flag on the ICMP packets
@@ -80,6 +80,32 @@ $cmd->stderr_like(qr{\[\d+:\d+:\d+\]
 \[\d+:\d+:\d+\]
 127\.0\.0\.1 : xmt/rcv/%loss = 5/5/0%, min/avg/max = \d\.\d+/\d\.\d+/\d\.\d+
 127\.0\.0\.1 : xmt/rcv/%loss = 6/6/0%, min/avg/max = \d\.\d+/\d\.\d+/\d\.\d+
+});
+}
+
+# fping -Q -o
+{
+my $cmd = Test::Command->new(cmd => "fping -c4 -Q1 -p550 -o 8.8.8.7");
+$cmd->exit_is_num(1);
+$cmd->stdout_is_eq("");
+$cmd->stderr_like(qr{\[\d+:\d+:\d+\]
+8\.8\.8\.7 : xmt/rcv/%loss = 1/0/100%, outage\(ms\) = 55\d
+\[\d+:\d+:\d+\]
+8\.8\.8\.7 : xmt/rcv/%loss = 2/0/100%, outage\(ms\) = 110\d
+8\.8\.8\.7 : xmt/rcv/%loss = 4/0/100%, outage\(ms\) = 220\d
+});
+}
+
+# fping -Q -o -F
+{
+my $cmd = Test::Command->new(cmd => "fping -c4 -Q1 -p550 -o -F 8.8.8.7");
+$cmd->exit_is_num(1);
+$cmd->stdout_is_eq("");
+$cmd->stderr_like(qr{\[\d+:\d+:\d+\]
+8\.8\.8\.7 : xmt/rcv/%loss = 1/0/100%, outage\(ms\) = 55\d
+\[\d+:\d+:\d+\]
+8\.8\.8\.7 : xmt/rcv/%loss = 3/0/100%, outage\(ms\) = 165\d
+8\.8\.8\.7 : xmt/rcv/%loss = 4/0/100%, outage\(ms\) = 220\d
 });
 }
 

--- a/doc/fping.pod
+++ b/doc/fping.pod
@@ -102,6 +102,11 @@ user. Regular users should pipe in the file via stdin:
 
  $ fping < targets_file
 
+=item B<-F>, B<--full>
+
+Print full per host statistics since fping start instead of per interval
+statistics in regular status reports enabled by B<-Q> I<SECS>.
+
 =item B<-g>, B<--generate> I<addr/mask>
 
 Generate a target list from a supplied IP netmask, or a starting and ending IP.

--- a/src/fping.c
+++ b/src/fping.c
@@ -1625,7 +1625,7 @@ void print_per_system_stats(void)
             else {
                 fprintf(stderr, " xmt/rcv/%%return = %d/%d/%d%%",
                     h->num_sent, h->num_recv,
-                    ((h->num_recv * 100) / h->num_sent));
+                    h->num_sent > 0 ? ((h->num_recv * 100) / h->num_sent) : 0);
             }
 
             if (h->num_recv) {

--- a/src/fping.c
+++ b/src/fping.c
@@ -380,6 +380,7 @@ void usage(int);
 int wait_for_reply(int64_t);
 void print_per_system_stats(void);
 void print_per_system_splits(void);
+void stats_reset_interval(HOST_ENTRY *h);
 void print_netdata(void);
 void print_global_stats(void);
 void main_loop();
@@ -1783,7 +1784,7 @@ void print_host_splits(HOST_ENTRY* h)
     }
 
     fprintf(stderr, "\n");
-    h->num_sent_i = h->num_recv_i = h->max_reply_i = h->min_reply_i = h->total_time_i = 0;
+    stats_reset_interval(h);
 }
 
 /************************************************************


### PR DESCRIPTION
This is a proof-of-concept implementation for the feature requested in issue #243.