### PR TITLE
add missing files to autoclean.sh

### DIFF
--- a/autoclean.sh
+++ b/autoclean.sh
@@ -4,6 +4,7 @@ rm -f Makefile
 rm -f Makefile.in
 rm -f aclocal.m4
 rm -rf autom4te.cache
+rm -f compile
 rm -f config.guess
 rm -f config.h
 rm -f config.h.in
@@ -16,7 +17,9 @@ rm -f install-sh
 rm -f missing
 rm -f mkinstalldirs
 rm -f stamp-h1
+rm -f doc/Makefile
 rm -f doc/Makefile.in
+rm -f src/Makefile
 rm -f src/Makefile.in
 rm -f doc/fping.8
 rm -f src/*.gcda


### PR DESCRIPTION
At least on my system (Ubuntu GNU/Linux 18.04.6 LTS), autoclean.sh
misses three files: compile, doc/Makefile, and src/Makefile.  Add
them.