### PR TITLE
Remove dublicate include time.h entry in fping.c

### DIFF
--- a/src/fping.c
+++ b/src/fping.c
@@ -60,8 +60,6 @@ extern "C" {
 #include <stddef.h>
 #include <string.h>
 
-#include <time.h>
-
 #include <sys/socket.h>
 #include <sys/time.h>
 #include <sys/types.h>


### PR DESCRIPTION
Remove dublicate include time.h entry in src/fping.c line 63.
The time.h is also included in line 48