### PR TITLE
distinguish ICMP and ICMP6 in error messages

### DIFF
--- a/src/socket6.c
+++ b/src/socket6.c
@@ -51,15 +51,15 @@ int open_ping_socket_ipv6(int *socktype)
     struct protoent* proto;
     int s;
 
-    /* confirm that ICMP is available on this machine */
+    /* confirm that ICMP6 is available on this machine */
     if ((proto = getprotobyname("ipv6-icmp")) == NULL)
-        crash_and_burn("icmp: unknown protocol");
+        crash_and_burn("ipv6-icmp: unknown protocol");
 
-    /* create raw socket for ICMP calls (ping) */
+    /* create raw socket for ICMP6 calls (ping) */
     *socktype = SOCK_RAW;
     s = socket(AF_INET6, *socktype, proto->p_proto);
     if (s < 0) {
-        /* try non-privileged icmp (works on Mac OSX without privileges, for example) */
+        /* try non-privileged icmp6 (works on Mac OSX without privileges, for example) */
         *socktype = SOCK_DGRAM;
         s = socket(AF_INET6, *socktype, proto->p_proto);
         if (s < 0) {
@@ -104,7 +104,7 @@ void socket_set_src_addr_ipv6(int s, struct in6_addr* src_addr, int *ident)
     if (ident) {
         memset(&sa, 0, len);
         if (getsockname(s, (struct sockaddr *)&sa, &len) < 0)
-            errno_crash_and_burn("can't get ICMP socket identity");
+            errno_crash_and_burn("can't get ICMP6 socket identity");
 
         if (sa.sin6_port)
             *ident = sa.sin6_port;


### PR DESCRIPTION
This is a suggestion to differentiate between some IPv4 and IPv6 socket related error messages.

1. After a failed attempt to get the protocol `ipv6-icmp` I think it would be better to say that this protocol could not be resolved instead of using just the name `icmp` in the error message.
    ```
    $ getent protocols icmp
    icmp                  1 ICMP
    $ getent protocols ipv6-icmp
    ipv6-icmp             58 IPv6-ICMP
    ```

2. When setting the source IPv6 address of an `AF_ICMP6` socket fails use `ICMP6` instead of `ICMP` in the error message.

This might help the user to start looking for IPv6 issues, or tying to find out why IPv6 is used in the first place. When the error messages look identically for both IPv4 and IPv6 the user might not even realize that the problem is related to IPv6 or even that IPv6 is in use at all.

Please let me know what you think.