### PR TITLE
emit error message when socket creation fails

### DIFF
--- a/src/fping.c
+++ b/src/fping.c
@@ -463,6 +463,9 @@ int main(int argc, char** argv)
         usage(0);
     }
 
+    /* enable error messages during socket creation */
+    verbose_flag = 1;
+
     socket4 = open_ping_socket_ipv4(&socktype4);
 #ifdef __linux__
     /* We only treat SOCK_DGRAM differently on Linux, where the IPv4 header
@@ -493,7 +496,6 @@ int main(int argc, char** argv)
 
     optparse_init(&optparse_state, argv);
     ident4 = ident6 = htons(getpid() & 0xFFFF);
-    verbose_flag = 1;
     backoff_flag = 1;
     opterr = 1;
 


### PR DESCRIPTION
This is the patch from my [comment on issue 201](https://github.com/schweikert/fping/issues/201#issuecomment-1077475551), but now I have tested it, and it works, at least for me. :-)

To test, I have temporarily changed the requested protocol name to something nonsensical. With the patch, an error message was emitted, but not without the patch.

I think a pull request like this was requested in a [comment on issue 201](https://github.com/schweikert/fping/issues/201#issuecomment-894614950).

My PR 250 (distinguish ICMP and ICMP6 in error messages) makes this error message more useful.