### PR TITLE
Update Netdata website link

### DIFF
--- a/doc/fping.pod
+++ b/doc/fping.pod
@@ -154,7 +154,7 @@ to print hostnames in the output.
 
 =item B<-N>, B<--netdata>
 
-Format output for netdata (-l -Q are required). See: L<https://www.netdata.cloud/>
+Format output for netdata (-l -Q are required). See: L<https://netdata.cloud/>
 
 =item B<-o>, B<--outage>
 

--- a/doc/fping.pod
+++ b/doc/fping.pod
@@ -154,7 +154,7 @@ to print hostnames in the output.
 
 =item B<-N>, B<--netdata>
 
-Format output for netdata (-l -Q are required). See: L<http://my-netdata.io/>
+Format output for netdata (-l -Q are required). See: L<https://www.netdata.cloud/>
 
 =item B<-o>, B<--outage>
 


### PR DESCRIPTION
`http://my-netdata.io/` technically works, but it redirects to `https://netdata.cloud/`. I think it is better to update the website link.