### PR TITLE
Fixing build warning long int on seqmap.c line 84

### DIFF
--- a/src/seqmap.c
+++ b/src/seqmap.c
@@ -41,6 +41,7 @@
 #include "options.h"
 #include "fping.h"
 
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -81,7 +82,7 @@ unsigned int seqmap_add(unsigned int host_nr, unsigned int ping_count, int64_t t
      * 0, so will be seen as expired */
     next_value = &seqmap_map[seqmap_next_id];
     if (timestamp - next_value->ping_ts < SEQMAP_TIMEOUT_IN_NS) {
-        fprintf(stderr, "fping error: not enough sequence numbers available! (expire_timeout=%ld, host_nr=%d, ping_count=%d, seqmap_next_id=%d)\n",
+        fprintf(stderr, "fping error: not enough sequence numbers available! (expire_timeout=%" PRId64 ", host_nr=%d, ping_count=%d, seqmap_next_id=%d)\n",
             SEQMAP_TIMEOUT_IN_NS, host_nr, ping_count, seqmap_next_id);
         exit(4);
     }


### PR DESCRIPTION
Fixes the following build warning under ARMv6 CPU

Version: fping-5.1
CPU: ARMv6
```
seqmap.c: In function ‘seqmap_add’:
seqmap.c:84:96: warning: format ‘%ld’ expects argument of type ‘long int’, but argument 3 has type ‘long long int’ [-Wformat=]
 ing error: not enough sequence numbers available! (expire_timeout=%ld, host_nr=%d, ping_count=%d, seqmap_next_id=%d)\n",
                                                                   ~~^
                                                                   %lld
```