### PR TITLE
Superfluous variable response_addr_len in function decode_icmp_ipv4

### DIFF
--- a/src/fping.c
+++ b/src/fping.c
@@ -2075,7 +2075,6 @@ void stats_reset_interval(HOST_ENTRY *h)
 
 int decode_icmp_ipv4(
     struct sockaddr* response_addr,
-    size_t response_addr_len,
     char* reply_buf,
     size_t reply_buf_len,
     unsigned short* id,
@@ -2308,7 +2307,6 @@ int wait_for_reply(int64_t wait_time)
     if (response_addr.ss_family == AF_INET) {
         int ip_hlen = decode_icmp_ipv4(
                 (struct sockaddr*)&response_addr,
-                sizeof(response_addr),
                 buffer,
                 sizeof(buffer),
                 &id,


### PR DESCRIPTION
Fixes the following build warning
```
fping.c: In function ‘decode_icmp_ipv4’:
fping.c:2078:12: warning: unused parameter ‘response_addr_len’ [-Wunused-parameter]
     size_t response_addr_len,
     ~~~~~~~^~~~~~~~~~~~~~~~~
```

The variable `response_addr_len` in function `decode_icmp_ipv4` has become redundant with the commit https://github.com/schweikert/fping/commit/bbe847a5d9ae20b5e27689cd485e62649fb32491