### PR TITLE
Updating doc regarding root requirements for file parameter

### DIFF
--- a/doc/fping.pod
+++ b/doc/fping.pod
@@ -97,10 +97,7 @@ Show elapsed (round-trip) time of packets.
 
 =item B<-f>, B<--file>
 
-Read list of targets from a file.  This option can only be used by the root
-user. Regular users should pipe in the file via stdin:
-
- $ fping < targets_file
+Read list of targets from a file.
 
 =item B<-g>, B<--generate> I<addr/mask>
 


### PR DESCRIPTION
'--file' has been allowed for non-root since 3.10 (see commit 86f0b1e38098ad4b7e735ee7ef10cda071d43bdc ).

This is to update the documentation since it does not reflect this change, which can be confusing.