### PR TITLE
OpenBSD is not affected by the "broken alpha headers" bug, too.

### DIFF
--- a/src/fping.c
+++ b/src/fping.c
@@ -2086,7 +2086,7 @@ int decode_icmp_ipv4(
     if (!using_sock_dgram4) {
         struct ip *ip = (struct ip *)reply_buf;
 
-#if defined(__alpha__) && __STDC__ && !defined(__GLIBC__) && !defined(__NetBSD__)
+#if defined(__alpha__) && __STDC__ && !defined(__GLIBC__) && !defined(__NetBSD__) && !defined(__OpenBSD__)
         /* The alpha headers are decidedly broken.
          * Using an ANSI compiler, it provides ip_vhl instead of ip_hl and
          * ip_v.  So, to get ip_hl, we mask off the bottom four bits.


### PR DESCRIPTION
For NetBSD this was implemented in PullRequest [225](https://github.com/schweikert/fping/pull/255)
This can also be found in the OpenBSD patch https://cvsweb.openbsd.org/cgi-bin/cvsweb/~checkout~/ports/net/fping/patches/patch-src_fping_c?rev=1.12&content-type=text/plain