### PR TITLE
Fallback to SO_TIMESTAMP if SO_TIMESTAMPNS is not available

### DIFF
--- a/src/fping.c
+++ b/src/fping.c
@@ -1007,13 +1007,17 @@ int main(int argc, char **argv)
         int opt = 1;
         if (socket4 >= 0) {
             if (setsockopt(socket4, SOL_SOCKET, SO_TIMESTAMPNS, &opt, sizeof(opt))) {
-                perror("setting SO_TIMESTAMPNS option");
+                if (setsockopt(socket4, SOL_SOCKET, SO_TIMESTAMP, &opt, sizeof(opt))) {
+                    perror("setting SO_TIMESTAMPNS and SO_TIMESTAMP option");
+                }
             }
         }
 #ifdef IPV6
         if (socket6 >= 0) {
             if (setsockopt(socket6, SOL_SOCKET, SO_TIMESTAMPNS, &opt, sizeof(opt))) {
-                perror("setting SO_TIMESTAMPNS option (IPv6)");
+                if (setsockopt(socket6, SOL_SOCKET, SO_TIMESTAMP, &opt, sizeof(opt))) {
+                    perror("setting SO_TIMESTAMPNS and SO_TIMESTAMP option (IPv6)");
+                }
             }
         }
 #endif


### PR DESCRIPTION
If the compiler correctly identifies the use of HAVE_SO_TIMESTAMPNS but in runtime SO_TIMESTAMPNS cannot be used, then SO_TIMESTAMP is tried to be used as fallback. Only if this also does not work, an error message is issued for both SO_TIMESTAMPNS and SO_TIMESTAMP.

Fixed Issues #272 and #273