### PR TITLE
Repair the faulty test 15

### DIFF
--- a/ci/test-15-netdata.pl
+++ b/ci/test-15-netdata.pl
@@ -9,19 +9,19 @@ plan tests => 3;
 {
 my $cmd = Test::Command->new(cmd => "fping -c 2 -Q 1 -N 127.0.0.1");
 $cmd->exit_is_num(0);
-$cmd->stdout_like(qr{CHART fping\.127_0_0_1_packets '' 'FPing Packets for host 127\.0\.0\.1' packets '127.0.0.1' fping\.packets line 110020 1
+$cmd->stdout_like(qr{CHART fping\.127_0_0_1_packets '' 'FPing Packets' packets '127.0.0.1' fping\.packets line 110020 1
 DIMENSION xmt sent absolute 1 1
 DIMENSION rcv received absolute 1 1
 BEGIN fping\.127_0_0_1_packets
 SET xmt = 1
 SET rcv = 1
 END
-CHART fping\.127_0_0_1_quality '' 'FPing Quality for host 127\.0\.0\.1' percentage '127.0.0.1' fping\.quality area 110010 1
+CHART fping\.127_0_0_1_quality '' 'FPing Quality' percentage '127.0.0.1' fping\.quality area 110010 1
 DIMENSION returned '' absolute 1 1
 BEGIN fping\.127_0_0_1_quality
 SET returned = 100
 END
-CHART fping\.127_0_0_1_latency '' 'FPing Latency for host 127\.0\.0\.1' ms '127.0.0.1' fping\.latency area 110000 1
+CHART fping\.127_0_0_1_latency '' 'FPing Latency' ms '127.0.0.1' fping\.latency area 110000 1
 DIMENSION min minimum absolute 1 1000000
 DIMENSION max maximum absolute 1 1000000
 DIMENSION avg average absolute 1 1000000


### PR DESCRIPTION
The erroneous test 15 was corrected, which did not work anymore with commit a6c3145 (remove host from netdata chart titles)