### PR TITLE
Fix deprected github action ubuntu-18.04 to ubuntu-22.04

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04]
+        os: [ubuntu-20.04, ubuntu-22.04]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2


### PR DESCRIPTION
I have changed the runner no longer present in github action from ubuntu-18-04 to ubuntu-22.04