### PR TITLE
Autoconf os detection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -7,11 +7,11 @@ AC_INIT([fping],[5.1])
 AC_GNU_SOURCE
 
 # Detect Operatingsystem
-AC_CANONICAL_HOST
+AC_CANONICAL_TARGET
 only_clock_realtime=no
 
-case "${host_os}" in
-  darwin*)
+case "${target}" in
+  *darwin*)
     only_clock_realtime=yes
     ;;
   *freebsd*)
@@ -66,7 +66,6 @@ AC_ARG_ENABLE([safe-limits],
 AS_IF([test "x$enable_safe_limits" = "xyes"], [
    AC_DEFINE(FPING_SAFE_LIMITS, [1], [safe limits should be enforced])])
 
-AC_CANONICAL_TARGET
 AM_INIT_AUTOMAKE([-Wall -Werror foreign])
 AM_MAINTAINER_MODE
 

--- a/configure.ac
+++ b/configure.ac
@@ -6,6 +6,22 @@ AC_PREREQ(2.59)
 AC_INIT([fping],[5.1])
 AC_GNU_SOURCE
 
+# Detect Operatingsystem
+AC_CANONICAL_HOST
+only_clock_realtime=no
+
+case "${host_os}" in
+  darwin*)
+    only_clock_realtime=yes
+    ;;
+  *freebsd*)
+    only_clock_realtime=yes
+    ;;
+  *openbsd*)
+    only_clock_realtime=yes
+    ;;
+esac
+
 dnl --disable-ipv4
 AC_ARG_ENABLE([ipv4],
   AS_HELP_STRING([--disable-ipv4], [Disable support for pinging IPv4 hosts]))
@@ -43,6 +59,7 @@ dnl Test if --enable-timestamp is explicitely enabled and make an error if this 
 AS_IF([test "x$enable_timestamp" = "xyes" -a "x$have_so_timestamp" = "xno"], [
   AC_MSG_ERROR([--enable-timestamp not supported on this platform])
 ])
+AS_IF([test "x$only_clock_realtime" = "xyes"], [AC_DEFINE(ONLY_CLOCK_REALTIME, [1], [ONLY_CLOCK_REALTIME is defined])])
 
 AC_ARG_ENABLE([safe-limits],
   AS_HELP_STRING([--enable-safe-limits], [Restrict timing parameters (-i, -p) within "safe" limits]))

--- a/src/fping.c
+++ b/src/fping.c
@@ -116,15 +116,16 @@ extern int h_errno;
 
 /*** Constants ***/
 
-#if HAVE_SO_TIMESTAMPNS
+/* CLOCK_MONTONIC starts under macOS, OpenBSD and FreeBSD with undefined positive point and can not be use
+ * see github PR #217
+ * The configure script detect the predefined operating systems an set CLOCK_REALTIME using over ONLY_CLOCK_REALTIME variable
+ */
+#if HAVE_SO_TIMESTAMPNS || ONLY_CLOCK_REALTIME
 #define CLOCKID CLOCK_REALTIME
 #endif
 
-/* CLOCK_MONTONIC starts under macOS, OpenBSD and FreeBSD with undefined positive point and can not be use
- * see github PR #217
- */
 #if !defined(CLOCKID)
-#if defined(CLOCK_MONOTONIC) && !defined(__APPLE__) && !defined(__OpenBSD__) && !defined(__FreeBSD__)
+#if defined(CLOCK_MONOTONIC)
 #define CLOCKID CLOCK_MONOTONIC
 #else
 #define CLOCKID CLOCK_REALTIME


### PR DESCRIPTION
- The operating system identification has moved from incode to autoconf.
- The first step is to control CLOCK_REALTIME.
- The next step could be the identification of system under WSL, which is currently not yet required.