### PR TITLE
Checking obsolete macro AC_GNU_SOURCE (autoconf-2.62) and AC_PROG_CC_STDC (autoconf-2.70) 

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -60,7 +60,7 @@ dnl Checks for programs.
 
 AC_PROG_CC
 AM_PROG_CC_C_O
-AC_PROG_CC_STDC
+m4_version_prereq([2.70],,[AC_PROG_CC_STDC])
 AC_PROG_CPP
 AC_PROG_INSTALL
 

--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,8 @@ dnl Minimum Autoconf version required.
 AC_PREREQ(2.59)
 
 AC_INIT([fping],[5.1])
-AC_GNU_SOURCE
+
+m4_ifdef([AC_AUTOCONF_VERSION],[AC_USE_SYSTEM_EXTENSIONS], [AC_GNU_SOURCE])
 
 dnl --disable-ipv4
 AC_ARG_ENABLE([ipv4],


### PR DESCRIPTION
Corrects the two warnings AC_GNU_SOURCE and AC_PROG_CC_STDC is obsolete when using autconf version >= 2.62 or 2.70
Issue: #284 