### PR TITLE
Add --fwmark option for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,14 @@ If you want to install fping from source, proceed as follows:
    (see: `./configure --help`)
 2. Run `make; make install`.
 3. Make fping either setuid, or, if under Linux:
-   `sudo setcap cap_net_raw+ep fping`
+   `sudo setcap cap_net_raw,cap_net_admin+ep fping`
 
 If you can't run fping as root or can't use the cap_net_raw capability, you can
 also run fping in unprivileged mode. This works on MacOS and also on Linux,
 provided that your GID is included in the range defined in
 `/proc/sys/net/ipv4/ping_group_range`. This is particularly useful for running
-fping in rootless / unprivileged containers.
+fping in rootless / unprivileged containers. The --fwmark option needs root or
+cap_net_admin. setuid will not work for --fwmark.
 
 ## Usage
 

--- a/ci/prepare-linux.sh
+++ b/ci/prepare-linux.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-sudo setcap cap_net_raw+ep src/fping
+sudo setcap cap_net_raw,cap_net_admin+ep src/fping
 
 if [[ ! $PATH =~ fping/src ]]; then
     PATH=/home/dws/checkouts/fping/src:$PATH

--- a/ci/test-07-options-i-m.pl
+++ b/ci/test-07-options-i-m.pl
@@ -1,10 +1,11 @@
 #!/usr/bin/perl -w
 
-use Test::Command tests => 9;
+use Test::Command tests => 12;
 use Test::More;
 
 #  -i n       interval between sending ping packets (in millisec) (default 25)
 #  -l         loop sending pings forever
+#  -k         set fwmark on ping packets
 #  -m         ping multiple interfaces on target host
 #  -M         don't fragment
 
@@ -22,6 +23,17 @@ my $cmd = Test::Command->new(cmd => '(sleep 2; pkill fping)& fping -p 900 -l 127
 $cmd->stdout_like(qr{127\.0\.0\.1 : \[0\], 64 bytes, \d\.\d+ ms \(\d\.\d+ avg, 0% loss\)
 127\.0\.0\.1 : \[1\], 64 bytes, \d\.\d+ ms \(\d\.\d+ avg, 0% loss\)
 });
+}
+
+# fping -k
+SKIP: {
+if($^O ne 'linux') {
+    skip '-k option is only supported on Linux', 3;
+}
+my $cmd = Test::Command->new(cmd => 'sudo env "PATH=$PATH" fping -k 256 127.0.0.1');
+$cmd->exit_is_num(0);
+$cmd->stdout_is_eq("127.0.0.1 is alive\n");
+$cmd->stderr_is_eq("");
 }
 
 # fping -l with SIGQUIT

--- a/contrib/fping.spec
+++ b/contrib/fping.spec
@@ -54,8 +54,8 @@ rm -rf $RPM_BUILD_ROOT
 %post
 if [ -x /usr/sbin/setcap ]; then
     /bin/chmod 0755 /usr/sbin/fping*
-    /usr/sbin/setcap cap_net_raw+ep /usr/sbin/fping
-    /usr/sbin/setcap cap_net_raw+ep /usr/sbin/fping6
+    /usr/sbin/setcap cap_net_raw,cap_net_admin+ep /usr/sbin/fping
+    /usr/sbin/setcap cap_net_raw,cap_net_admin+ep /usr/sbin/fping6
 fi
 
 %changelog

--- a/doc/fping.pod
+++ b/doc/fping.pod
@@ -130,6 +130,11 @@ to any target (default is 10, minimum is 1).
 
 Set the interface (requires SO_BINDTODEVICE support).
 
+=item B<-k>, B<--fwmark>=I<FWMARK>
+
+Set FWMARK on ping packets for policy-based routing. Requires Linux kernel
+2.6.25<=, and root privileges or cap_net_admin.
+
 =item B<-l>, B<--loop>
 
 Loop sending packets to each target indefinitely. Can be interrupted with


### PR DESCRIPTION
This is based on [tomangert](https://github.com/tomangert)'s original outdated pull request.

--fwmark can be used in conjunction with `ip rule` and `ip route` to route ping packets based on the mark set by the aforementioned flag.

This has been supported by Linux since kernel version [2.6.25](https://man7.org/linux/man-pages/man7/socket.7.html)

Let me know if you'd like any changes.