### PR TITLE
Use CLOCK_REALTIME when logging and CLOCK_MONOTONIC when timing

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -9,19 +9,6 @@ m4_ifdef([AC_AUTOCONF_VERSION],[AC_USE_SYSTEM_EXTENSIONS], [AC_GNU_SOURCE])
 
 # Detect Operatingsystem
 AC_CANONICAL_TARGET
-only_clock_realtime=no
-
-case "${target}" in
-  *darwin*)
-    only_clock_realtime=yes
-    ;;
-  *freebsd*)
-    only_clock_realtime=yes
-    ;;
-  *openbsd*)
-    only_clock_realtime=yes
-    ;;
-esac
 
 dnl --disable-ipv4
 AC_ARG_ENABLE([ipv4],
@@ -60,7 +47,6 @@ dnl Test if --enable-timestamp is explicitely enabled and make an error if this 
 AS_IF([test "x$enable_timestamp" = "xyes" -a "x$have_so_timestamp" = "xno"], [
   AC_MSG_ERROR([--enable-timestamp not supported on this platform])
 ])
-AS_IF([test "x$only_clock_realtime" = "xyes"], [AC_DEFINE(ONLY_CLOCK_REALTIME, [1], [ONLY_CLOCK_REALTIME is defined])])
 
 AC_ARG_ENABLE([safe-limits],
   AS_HELP_STRING([--enable-safe-limits], [Restrict timing parameters (-i, -p) within "safe" limits]))

--- a/src/seqmap.c
+++ b/src/seqmap.c
@@ -81,9 +81,9 @@ unsigned int seqmap_add(unsigned int host_nr, unsigned int ping_count, int64_t t
     /* check if expired (note that unused seqmap values will have fields set to
      * 0, so will be seen as expired */
     next_value = &seqmap_map[seqmap_next_id];
-    if (timestamp - next_value->ping_ts < SEQMAP_TIMEOUT_IN_NS) {
-        fprintf(stderr, "fping error: not enough sequence numbers available! (expire_timeout=%" PRId64 ", host_nr=%d, ping_count=%d, seqmap_next_id=%d)\n",
-            SEQMAP_TIMEOUT_IN_NS, host_nr, ping_count, seqmap_next_id);
+    if (next_value->ping_ts != 0 && timestamp - next_value->ping_ts < SEQMAP_TIMEOUT_IN_NS) {
+        fprintf(stderr, "fping error: not enough sequence numbers available! (expire_timeout=%" PRId64 ", host_nr=%d, ping_count=%d, seqmap_next_id=%d ping_st=%" PRId64 ")\n",
+		SEQMAP_TIMEOUT_IN_NS, host_nr, ping_count, seqmap_next_id, next_value->ping_ts);
         exit(4);
     }
 


### PR DESCRIPTION
Change update_current_time() so that current_time is set from CLOCK_REALTIME and current_time_ms is set from CLOCK_MONOTONIC.  This way log messages display wall clock time while any timing calculations use monotonic time.

See #203

In seqmap_add(), before checking to see if .time_ts wrapped, check that .time_ts was set.

See #288