### PR TITLE
Defensive coding: guard against a division by zero

### DIFF
--- a/src/fping.c
+++ b/src/fping.c
@@ -1655,7 +1655,7 @@ void print_per_system_stats(void)
             else {
                 fprintf(stderr, " xmt/rcv/%%return = %d/%d/%d%%",
                     h->num_sent, h->num_recv,
-                    ((h->num_recv * 100) / h->num_sent));
+                    h->num_sent > 0 ? ((h->num_recv * 100) / h->num_sent) : 0);
             }
 
             if (h->num_recv) {


### PR DESCRIPTION
In the function print_per_system_stats(), if packets have been lost, the number of sent packets is checked to be positive before dividing by it.  If no packets have been lost, this is not checked. Either the existing check is not needed, or both code paths need the check.

The function print_per_system_splits() is quite similar to print_per_system_stats(), and has the equivalent guards against a division by zero in both code paths, not just one of them.

In the spirit of defensive coding, I think it is better to be safe and add the missing guard against a division by zero.