### PR TITLE
Options "-c N" / "-C N" versus "-a" and "-u" (v2)

### DIFF
--- a/ci/test-05-options-c-e.pl
+++ b/ci/test-05-options-c-e.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 
-use Test::Command tests => 18;
+use Test::Command tests => 33;
 
 #  -c n       count of pings to send to each target (default 1)
 #  -C n       same as -c, report results in verbose format
@@ -10,6 +10,46 @@ use Test::Command tests => 18;
 # fping -c n
 {
 my $cmd = Test::Command->new(cmd => "fping -4 -c 2 -p 100 localhost 127.0.0.1");
+$cmd->exit_is_num(0);
+$cmd->stdout_like(qr{localhost : \[0\], 64 bytes, \d\.\d+ ms \(\d\.\d+ avg, 0% loss\)
+127\.0\.0\.1 : \[0\], 64 bytes, \d\.\d+ ms \(\d\.\d+ avg, 0% loss\)
+localhost : \[1\], 64 bytes, \d\.\d+ ms \(\d\.\d+ avg, 0% loss\)
+127\.0\.0\.1 : \[1\], 64 bytes, \d\.\d+ ms \(\d\.\d+ avg, 0% loss\)
+});
+
+$cmd->stderr_like(qr{localhost : xmt/rcv/%loss = 2/2/0%, min/avg/max = \d\.\d+/\d\.\d+/\d\.\d+
+127\.0\.0\.1 : xmt/rcv/%loss = 2/2/0%, min/avg/max = \d\.\d+/\d\.\d+/\d\.\d+
+});
+}
+
+# fping -c n -q
+{
+my $cmd = Test::Command->new(cmd => "fping -q -c 2 -p 100 localhost 127.0.0.1");
+$cmd->exit_is_num(0);
+$cmd->stdout_is_eq("");
+$cmd->stderr_like(qr{localhost : xmt/rcv/%loss = 2/2/0%, min/avg/max = \d\.\d+/\d\.\d+/\d\.\d+
+127\.0\.0\.1 : xmt/rcv/%loss = 2/2/0%, min/avg/max = \d\.\d+/\d\.\d+/\d\.\d+
+});
+}
+
+# fping -c n -a (-a is ignored)
+{
+my $cmd = Test::Command->new(cmd => "fping -a -c 2 -p 100 localhost 127.0.0.1");
+$cmd->exit_is_num(0);
+$cmd->stdout_like(qr{localhost : \[0\], 64 bytes, \d\.\d+ ms \(\d\.\d+ avg, 0% loss\)
+127\.0\.0\.1 : \[0\], 64 bytes, \d\.\d+ ms \(\d\.\d+ avg, 0% loss\)
+localhost : \[1\], 64 bytes, \d\.\d+ ms \(\d\.\d+ avg, 0% loss\)
+127\.0\.0\.1 : \[1\], 64 bytes, \d\.\d+ ms \(\d\.\d+ avg, 0% loss\)
+});
+
+$cmd->stderr_like(qr{localhost : xmt/rcv/%loss = 2/2/0%, min/avg/max = \d\.\d+/\d\.\d+/\d\.\d+
+127\.0\.0\.1 : xmt/rcv/%loss = 2/2/0%, min/avg/max = \d\.\d+/\d\.\d+/\d\.\d+
+});
+}
+
+# fping -c n -u (-u is ignored)
+{
+my $cmd = Test::Command->new(cmd => "fping -u -c 2 -p 100 localhost 127.0.0.1");
 $cmd->exit_is_num(0);
 $cmd->stdout_like(qr{localhost : \[0\], 64 bytes, \d\.\d+ ms \(\d\.\d+ avg, 0% loss\)
 127\.0\.0\.1 : \[0\], 64 bytes, \d\.\d+ ms \(\d\.\d+ avg, 0% loss\)
@@ -43,6 +83,36 @@ my $cmd = Test::Command->new(cmd => "fping -C 5 -q -p 100 localhost");
 $cmd->exit_is_num(0);
 $cmd->stdout_is_eq("");
 $cmd->stderr_like(qr{localhost :( \d\.\d+){5}
+});
+}
+
+# fping -C n -a (-a is ignored)
+{
+my $cmd = Test::Command->new(cmd => "fping -a -C 2 -p 100 localhost 127.0.0.1");
+$cmd->exit_is_num(0);
+$cmd->stdout_like(qr{localhost : \[0\], 64 bytes, \d\.\d+ ms \(\d\.\d+ avg, 0% loss\)
+127\.0\.0\.1 : \[0\], 64 bytes, \d\.\d+ ms \(\d\.\d+ avg, 0% loss\)
+localhost : \[1\], 64 bytes, \d\.\d+ ms \(\d\.\d+ avg, 0% loss\)
+127\.0\.0\.1 : \[1\], 64 bytes, \d\.\d+ ms \(\d\.\d+ avg, 0% loss\)
+});
+
+$cmd->stderr_like(qr{localhost : \d\.\d+ \d\.\d+
+127\.0\.0\.1 : \d\.\d+ \d\.\d+
+});
+}
+
+# fping -C n -u (-u is ignored)
+{
+my $cmd = Test::Command->new(cmd => "fping -u -C 2 -p 100 localhost 127.0.0.1");
+$cmd->exit_is_num(0);
+$cmd->stdout_like(qr{localhost : \[0\], 64 bytes, \d\.\d+ ms \(\d\.\d+ avg, 0% loss\)
+127\.0\.0\.1 : \[0\], 64 bytes, \d\.\d+ ms \(\d\.\d+ avg, 0% loss\)
+localhost : \[1\], 64 bytes, \d\.\d+ ms \(\d\.\d+ avg, 0% loss\)
+127\.0\.0\.1 : \[1\], 64 bytes, \d\.\d+ ms \(\d\.\d+ avg, 0% loss\)
+});
+
+$cmd->stderr_like(qr{localhost : \d\.\d+ \d\.\d+
+127\.0\.0\.1 : \d\.\d+ \d\.\d+
 });
 }
 

--- a/doc/fping.pod
+++ b/doc/fping.pod
@@ -66,7 +66,8 @@ default is 1.5.
 Number of request packets to send to each target.  In this mode, a line is
 displayed for each received response (this can suppressed with B<-q> or B<-Q>).
 Also, statistics about responses for each target are displayed when all
-requests have been sent (or when interrupted).
+requests have been sent (or when interrupted).  This option overrides B<-a>
+or B<-u>.
 
 =item B<-C>, B<--vcount>=I<N>
 
@@ -77,7 +78,8 @@ designed for automated response-time statistics gathering. For example:
  somehost : 91.7 37.0 29.2 - 36.8
 
 shows the response time in milliseconds for each of the five requests, with the
-C<-> indicating that no response was received to the fourth request.
+C<-> indicating that no response was received to the fourth request.  This
+option overrides B<-a> or B<-u>.
 
 =item B<-d>, B<--rdns>
 

--- a/src/fping.c
+++ b/src/fping.c
@@ -919,9 +919,6 @@ int main(int argc, char **argv)
         exit(1);
     }
 
-    if (alive_flag || unreachable_flag || min_reachable)
-        verbose_flag = 0;
-
     if (count_flag) {
         if (verbose_flag)
             per_recv_flag = 1;
@@ -935,6 +932,9 @@ int main(int argc, char **argv)
 
         alive_flag = unreachable_flag = verbose_flag = 0;
     }
+
+    if (alive_flag || unreachable_flag || min_reachable)
+        verbose_flag = 0;
 
     trials = (count > retry + 1) ? count : retry + 1;
 

--- a/src/fping.c
+++ b/src/fping.c
@@ -2943,6 +2943,7 @@ void usage(int is_error)
     fprintf(out, "                      (give start and end IP in the target list, or a CIDR address)\n");
     fprintf(out, "                      (ex. %s -g 192.168.1.0 192.168.1.255 or %s -g 192.168.1.0/24)\n", prog, prog);
     fprintf(out, "   -H, --ttl=N        set the IP TTL value (Time To Live hops)\n");
+    fprintf(out, "   -i, --interval=MSEC  interval between sending ping packets (default: %.0f ms)\n", interval / 1e6);
 #ifdef SO_BINDTODEVICE
     fprintf(out, "   -I, --iface=IFACE  bind to a particular interface\n");
 #endif
@@ -2968,7 +2969,6 @@ void usage(int is_error)
     fprintf(out, "   -d, --rdns         show targets by name (force reverse-DNS lookup)\n");
     fprintf(out, "   -D, --timestamp    print timestamp before each output line\n");
     fprintf(out, "   -e, --elapsed      show elapsed time on return packets\n");
-    fprintf(out, "   -i, --interval=MSEC  interval between sending ping packets (default: %.0f ms)\n", interval / 1e6);
     fprintf(out, "   -n, --name         show targets by name (reverse-DNS lookup for target IPs)\n");
     fprintf(out, "   -N, --netdata      output compatible for netdata (-l -Q are required)\n");
     fprintf(out, "   -o, --outage       show the accumulated outage time (lost packets * packet interval)\n");


### PR DESCRIPTION
1. Adjust fping -h output to emphasize that -i MSEC does not change the output format.
2. Ensure that neither -a nor -u affect -c N resp. -C N operation, and test this.
3. Document in the man page that -c N and -C N override -a or -u.

This addresses issue #295. It should also help at least somewhat with issues #271 and #274.