### PR TITLE
always output error message in crash_and_burn()

### DIFF
--- a/src/fping.c
+++ b/src/fping.c
@@ -2680,9 +2680,7 @@ void add_addr(char *name, char *host, struct sockaddr *ipaddr, socklen_t ipaddr_
 
 void crash_and_burn(char *message)
 {
-    if (verbose_flag)
-        fprintf(stderr, "%s: %s\n", prog, message);
-
+    fprintf(stderr, "%s: %s\n", prog, message);
     exit(4);
 }
 


### PR DESCRIPTION
This aligns crash_and_burn() with errno_crash_and_burn() and addresses issue #300.