### PR TITLE
Check if the variable next_value->ping_ts != 0 in seqmap_add()

### DIFF
--- a/src/seqmap.c
+++ b/src/seqmap.c
@@ -81,7 +81,7 @@ unsigned int seqmap_add(unsigned int host_nr, unsigned int ping_count, int64_t t
     /* check if expired (note that unused seqmap values will have fields set to
      * 0, so will be seen as expired */
     next_value = &seqmap_map[seqmap_next_id];
-    if (timestamp - next_value->ping_ts < SEQMAP_TIMEOUT_IN_NS) {
+    if (next_value->ping_ts != 0 && timestamp - next_value->ping_ts < SEQMAP_TIMEOUT_IN_NS) {
         fprintf(stderr, "fping error: not enough sequence numbers available! (expire_timeout=%" PRId64 ", host_nr=%d, ping_count=%d, seqmap_next_id=%d)\n",
             SEQMAP_TIMEOUT_IN_NS, host_nr, ping_count, seqmap_next_id);
         exit(4);


### PR DESCRIPTION
This pull request is a reduced version of @cagney and also fixes error #290 .
With this solution, however, the CPU time is faster than with pull request #306, which also fixes the error