### PR TITLE
Prefer SOCK_DGRAM

### DIFF
--- a/src/socket4.c
+++ b/src/socket4.c
@@ -56,12 +56,12 @@ int open_ping_socket_ipv4(int *socktype)
     if ((proto = getprotobyname("icmp")) == NULL)
         crash_and_burn("icmp: unknown protocol");
 
-    /* create raw socket for ICMP calls (ping) */
-    *socktype = SOCK_RAW;
+    /* try non-privileged icmp (works on Mac OSX without privileges, for example) */
+    *socktype = SOCK_DGRAM;
     s = socket(AF_INET, *socktype, proto->p_proto);
     if (s < 0) {
-        /* try non-privileged icmp (works on Mac OSX without privileges, for example) */
-        *socktype = SOCK_DGRAM;
+        /* fall back to raw socket for ICMP calls (ping) */
+        *socktype = SOCK_RAW;
         s = socket(AF_INET, *socktype, proto->p_proto);
         if (s < 0) {
             return -1;

--- a/src/socket6.c
+++ b/src/socket6.c
@@ -55,12 +55,12 @@ int open_ping_socket_ipv6(int *socktype)
     if ((proto = getprotobyname("ipv6-icmp")) == NULL)
         crash_and_burn("ipv6-icmp: unknown protocol");
 
-    /* create raw socket for ICMP6 calls (ping) */
-    *socktype = SOCK_RAW;
+    /* try non-privileged icmp6 (works on Mac OSX without privileges, for example) */
+    *socktype = SOCK_DGRAM;
     s = socket(AF_INET6, *socktype, proto->p_proto);
     if (s < 0) {
-        /* try non-privileged icmp6 (works on Mac OSX without privileges, for example) */
-        *socktype = SOCK_DGRAM;
+        /* fall back to raw socket for ICMP6 calls (ping) */
+        *socktype = SOCK_RAW;
         s = socket(AF_INET6, *socktype, proto->p_proto);
         if (s < 0) {
             return -1;


### PR DESCRIPTION
ping(8) from iputils-20240117 prefers SOCK_DGRAM instead of SOCK_RAW, which has a bonus of using kernel-assigned Identification. Apart from unprivileged operations, this also avoids collisions caused by user-assigned Identification on busy monitoring hosts (see also: birthday paradox).

So let's try SOCK_DGRAM first, and only if that fails, fall back to SOCK_RAW.