### PR TITLE
ci: skip an unreliable test on macOS

### DIFF
--- a/ci/test-07-options-i-m.pl
+++ b/ci/test-07-options-i-m.pl
@@ -51,7 +51,10 @@ $cmd->stderr_like(qr{\[\d+:\d+:\d+\]
 }
 
 # fping -l -Q
-{
+SKIP: {
+if($^O eq 'darwin') {
+    skip 'On macOS, this test is unreliable', 2;
+}
 my $cmd = Test::Command->new(cmd => '(sleep 2; pkill fping)& fping -p 850 -l -Q 1 127.0.0.1');
 $cmd->stdout_is_eq("");
 $cmd->stderr_like(qr{\[\d\d:\d\d:\d\d\]


### PR DESCRIPTION
Sometimes, this test fails on macOS, at least on the GitHub CI. It looks as if the fping process is killed before it produces the required output.  This test works reliably on GNU/Linux, so keep it, but skip it when running on macOS.