### PR TITLE
Some additional tests

### DIFF
--- a/ci/test-05-options-c-e.pl
+++ b/ci/test-05-options-c-e.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 
-use Test::Command tests => 48;
+use Test::Command tests => 51;
 
 #  -c n       count of pings to send to each target (default 1)
 #  -C n       same as -c, report results in verbose format
@@ -134,6 +134,17 @@ $cmd->stdout_like(qr{\[\d+\.\d+\] 127\.0\.0\.1 : \[0\], 64 bytes, \d\.\d+ ms \(\
 \[\d+\.\d+\] 127\.0\.0\.1 : \[1\], 64 bytes, \d\.\d+ ms \(\d\.\d+ avg, 0% loss\)
 });
 
+$cmd->stderr_like(qr{127\.0\.0\.1 : xmt/rcv/%loss = 2/2/0%, min/avg/max = \d\.\d+/\d\.\d+/\d\.\d+
+});
+}
+
+# fping -D (timestamp not before 2001-09-09)
+{
+my $cmd = Test::Command->new(cmd => "fping -D -c 2 -p 100 127.0.0.1");
+$cmd->exit_is_num(0);
+$cmd->stdout_like(qr{\[[1-9]\d{9,}\.\d+\] 127\.0\.0\.1 : \[0\], 64 bytes, \d\.\d+ ms \(\d\.\d+ avg, 0% loss\)
+\[[1-9]\d{9,}\.\d+\] 127\.0\.0\.1 : \[1\], 64 bytes, \d\.\d+ ms \(\d\.\d+ avg, 0% loss\)
+});
 $cmd->stderr_like(qr{127\.0\.0\.1 : xmt/rcv/%loss = 2/2/0%, min/avg/max = \d\.\d+/\d\.\d+/\d\.\d+
 });
 }

--- a/ci/test-12-option-type.pl
+++ b/ci/test-12-option-type.pl
@@ -1,22 +1,27 @@
 #!/usr/bin/perl -w
 
-use Test::Command tests => 42;
+use Test::Command tests => 84;
 use Test::More;
 
+# some options require a numeric argument
 for my $arg (qw(b B c C H i O p Q r t x X)) {
-    my $cmd = Test::Command->new(cmd => "fping -$arg xxx");
-    $cmd->exit_is_num(1);
-    $cmd->stdout_is_eq("");
-    $cmd->stderr_like(qr{Usage:});
+    for my $test_input (qw(xxx '')) {
+        my $cmd = Test::Command->new(cmd => "fping -$arg $test_input");
+        $cmd->exit_is_num(1);
+        $cmd->stdout_is_eq("");
+        $cmd->stderr_like(qr{Usage:});
+    }
 }
 
 # fping -k, only supported on Linux, requires a number
 SKIP: {
     if($^O ne 'linux') {
-        skip '-k option is only supported on Linux', 3;
+        skip '-k option is only supported on Linux', 6;
     }
-    my $cmd = Test::Command->new(cmd => 'fping -k xxx 127.0.0.1');
-    $cmd->exit_is_num(1);
-    $cmd->stdout_is_eq("");
-    $cmd->stderr_like(qr{Usage:});
+    for my $test_input (qw(xxx '')) {
+        my $cmd = Test::Command->new(cmd => "fping -k $test_input 127.0.0.1");
+        $cmd->exit_is_num(1);
+        $cmd->stdout_is_eq("");
+        $cmd->stderr_like(qr{Usage:});
+    }
 }


### PR DESCRIPTION
* Test that an empty string as option argument is rejected when the option argument needs to be a number.
* Test that the Unix timestamp produced with `-D` is not much older than would be expected.