### PR TITLE
Generator limit

### DIFF
--- a/ci/test-06-options-f-h.pl
+++ b/ci/test-06-options-f-h.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 
-use Test::Command tests => 72;
+use Test::Command tests => 75;
 use Test::More;
 use File::Temp;
 
@@ -168,6 +168,14 @@ my $cmd = Test::Command->new(cmd => "fping -g 127.0.0.2/0");
 $cmd->exit_is_num(1);
 $cmd->stdout_is_eq("");
 $cmd->stderr_is_eq("fping: netmask must be between 1 and 32 (is: 0)\n");
+}
+
+# fping -g (cidr - too many addresses)
+{
+my $cmd = Test::Command->new(cmd => "fping -g 127.0.0.0/8");
+$cmd->exit_is_num(1);
+$cmd->stdout_is_eq("");
+$cmd->stderr_is_eq("fping: -g parameter generates too many addresses\n");
 }
 
 # fping -g (range - no IPv6 generator)

--- a/doc/fping.pod
+++ b/doc/fping.pod
@@ -294,6 +294,9 @@ line arguments, and 4 for a system call failure.
 
 =head1 RESTRICTIONS
 
+The number of addresses that can be generated using the C<-g>, C<--generate>
+option is limited to 100001.
+
 If fping was configured with C<--enable-safe-limits>, the following values are
 not allowed for non-root users:
 

--- a/doc/fping.pod
+++ b/doc/fping.pod
@@ -295,7 +295,8 @@ line arguments, and 4 for a system call failure.
 =head1 RESTRICTIONS
 
 The number of addresses that can be generated using the C<-g>, C<--generate>
-option is limited to 100000.
+option is limited to 131070 (the number of host addresses in one 15-bit IPv4
+prefix).
 
 If fping was configured with C<--enable-safe-limits>, the following values are
 not allowed for non-root users:

--- a/doc/fping.pod
+++ b/doc/fping.pod
@@ -295,7 +295,7 @@ line arguments, and 4 for a system call failure.
 =head1 RESTRICTIONS
 
 The number of addresses that can be generated using the C<-g>, C<--generate>
-option is limited to 100001.
+option is limited to 100000.
 
 If fping was configured with C<--enable-safe-limits>, the following values are
 not allowed for non-root users:

--- a/src/fping.c
+++ b/src/fping.c
@@ -1282,6 +1282,7 @@ void add_cidr(char *addr)
         exit(1);
     }
     net_addr = ntohl(((struct sockaddr_in *)addr_res->ai_addr)->sin_addr.s_addr);
+    freeaddrinfo(addr_res);
 
     /* check mask */
     if (mask < 1 || mask > 32) {
@@ -1310,8 +1311,6 @@ void add_cidr(char *addr)
         inet_ntop(AF_INET, &in_addr_tmp, buffer, sizeof(buffer));
         add_name(buffer);
     }
-
-    freeaddrinfo(addr_res);
 }
 
 void add_range(char *start, char *end)
@@ -1355,6 +1354,7 @@ void add_range(char *start, char *end)
     end_long = ntohl(((struct sockaddr_in *)addr_res->ai_addr)->sin_addr.s_addr);
     freeaddrinfo(addr_res);
 
+    /* check if generator limit is exceeded */
     if (end_long > start_long + MAX_GENERATE) {
         fprintf(stderr, "%s: -g parameter generates too many addresses\n", prog);
         exit(1);

--- a/src/fping.c
+++ b/src/fping.c
@@ -139,7 +139,7 @@ extern int h_errno;
 #define SIZE_ICMP_HDR 8 /* from ip_icmp.h */
 #define MAX_PING_DATA (MAX_IP_PACKET - SIZE_IP_HDR - SIZE_ICMP_HDR)
 
-#define MAX_GENERATE 100000 /* maximum number of hosts that -g can generate */
+#define MAX_GENERATE 131070 /* maximum number of hosts that -g can generate */
 
 /* sized so as to be like traditional ping */
 #define DEFAULT_PING_DATA_SIZE 56

--- a/src/fping.c
+++ b/src/fping.c
@@ -1356,7 +1356,7 @@ void add_range(char *start, char *end)
 void add_addr_range_ipv4(unsigned long start_long, unsigned long end_long)
 {
     /* check if generator limit is exceeded */
-    if (end_long > start_long + MAX_GENERATE) {
+    if (end_long >= start_long + MAX_GENERATE) {
         fprintf(stderr, "%s: -g parameter generates too many addresses\n", prog);
         exit(1);
     }
@@ -3015,7 +3015,7 @@ void usage(int is_error)
     fprintf(out, "   -c, --count=N      count mode: send N pings to each target and report stats\n");
     fprintf(out, "   -f, --file=FILE    read list of targets from a file ( - means stdin)\n");
     fprintf(out, "   -g, --generate     generate target list (only if no -f specified),\n");
-    fprintf(out, "                      limited to at most %d targets\n", MAX_GENERATE+1);
+    fprintf(out, "                      limited to at most %d targets\n", MAX_GENERATE);
     fprintf(out, "                      (give start and end IP in the target list, or a CIDR address)\n");
     fprintf(out, "                      (ex. %s -g 192.168.1.0 192.168.1.255 or %s -g 192.168.1.0/24)\n", prog, prog);
     fprintf(out, "   -H, --ttl=N        set the IP TTL value (Time To Live hops)\n");


### PR DESCRIPTION
This pull request addresses GitHub issue #299 by:

* using the same maximum number of generated addresses for both range and CIDR arguments,
* fixing the off-by-one error in the generator limit, and
* increasing the limit to allow a 15-bit IPv4 prefix as generator input, or a range of the same size.

The generator limit is not exactly tested via CI, because pinging 100000 (or 100001) localhost IPv4 addresses takes more than 15 minutes on my computer. Testing 2^17-2 localhost IPv4 addresses takes more than 20 minutes on my computer. Thus I have tested this only manually.