### PR TITLE
new option --check-source

### DIFF
--- a/ci/test-02-help.pl
+++ b/ci/test-02-help.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 
-use Test::Command tests => 12;
+use Test::Command tests => 15;
 
 my $I_HELP = "   -I, --iface=IFACE  bind to a particular interface\n";
 $I_HELP = '' if $^O eq 'darwin';
@@ -38,3 +38,9 @@ my $cmd3 = Test::Command->new(cmd => "fping -Z");
 $cmd3->exit_is_num(1);
 $cmd3->stdout_is_eq("");
 $cmd3->stderr_like(qr{^fping: (illegal|invalid) option -- '?Z'?\nsee 'fping -h' for usage information\n$});
+
+# fping with unknown long option
+my $cmd5 = Test::Command->new(cmd => "fping --unknown-long-option");
+$cmd5->exit_is_num(1);
+$cmd5->stdout_is_eq("");
+$cmd5->stderr_like(qr{^fping: (illegal|invalid) option -- '?unknown-long-option'?\nsee 'fping -h' for usage information\n$});

--- a/ci/test-02-help.pl
+++ b/ci/test-02-help.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 
-use Test::Command tests => 15;
+use Test::Command tests => 18;
 
 my $I_HELP = "   -I, --iface=IFACE  bind to a particular interface\n";
 $I_HELP = '' if $^O eq 'darwin';
@@ -44,3 +44,9 @@ my $cmd5 = Test::Command->new(cmd => "fping --unknown-long-option");
 $cmd5->exit_is_num(1);
 $cmd5->stdout_is_eq("");
 $cmd5->stderr_like(qr{^fping: (illegal|invalid) option -- '?unknown-long-option'?\nsee 'fping -h' for usage information\n$});
+
+# fping with short option used to indicate long-only option
+my $cmd6 = Test::Command->new(cmd => "fping -0 127.0.0.1 127.0.0.2");
+$cmd6->exit_is_num(1);
+$cmd6->stdout_is_eq("");
+$cmd6->stderr_like(qr{Usage:});

--- a/doc/fping.pod
+++ b/doc/fping.pod
@@ -81,6 +81,13 @@ shows the response time in milliseconds for each of the five requests, with the
 C<-> indicating that no response was received to the fourth request.  This
 option overrides B<-a> or B<-u>.
 
+=item B<--check-source>
+
+Discard Echo replies that are sourced from a different address than the target
+address. This avoids spurious reachability results on busy monitoring systems
+where two B<fping> instances with the same lower 16 bits of the process ID may
+be running at the same time.
+
 =item B<-d>, B<--rdns>
 
 Use DNS to lookup address of ping target. This allows you to give fping

--- a/src/fping.c
+++ b/src/fping.c
@@ -580,6 +580,8 @@ int main(int argc, char **argv)
               }
             } else if(strstr(optparse_state.optlongname, "check-source") != NULL) {
                 check_source_flag = 1;
+            } else {
+                usage(1);
             }
             break;
         case '4':

--- a/src/fping.c
+++ b/src/fping.c
@@ -360,6 +360,7 @@ int timestamp_flag = 0;
 int timestamp_format_flag = 0;
 int random_data_flag = 0;
 int cumulative_stats_flag = 0;
+int check_source_flag = 0;
 #if defined(DEBUG) || defined(_DEBUG)
 int randomly_lose_flag, trace_flag, print_per_system_flag;
 int lose_factor;
@@ -556,6 +557,7 @@ int main(int argc, char **argv)
         { "version", 'v', OPTPARSE_NONE },
         { "reachable", 'x', OPTPARSE_REQUIRED },
         { "fast-reachable", 'X', OPTPARSE_REQUIRED },
+        { "check-source", '0', OPTPARSE_NONE },
 #if defined(DEBUG) || defined(_DEBUG)
         { NULL, 'z', OPTPARSE_REQUIRED },
 #endif
@@ -576,6 +578,8 @@ int main(int argc, char **argv)
               }else{
                 usage(1);
               }
+            } else if(strstr(optparse_state.optlongname, "check-source") != NULL) {
+                check_source_flag = 1;
             }
             break;
         case '4':
@@ -2436,6 +2440,12 @@ int wait_for_reply(int64_t wait_time)
 
     dbg_printf("received [%d] from %s\n", this_count, h->host);
 
+    /* optionally require reply source equal to target address */
+    if (check_source_flag && addr_cmp((struct sockaddr *)&response_addr, (struct sockaddr *)&h->saddr)) {
+        dbg_printf("discarding reply from wrong source address\n");
+        return 1;
+    }
+
     /* discard duplicates */
     if (!loop_flag && h->resp_times[this_count] >= 0) {
         if (!per_recv_flag) {
@@ -3037,6 +3047,7 @@ void usage(int is_error)
     fprintf(out, "   -S, --src=IP       set source address\n");
     fprintf(out, "   -t, --timeout=MSEC individual target initial timeout (default: %.0f ms,\n", timeout / 1e6);
     fprintf(out, "                      except with -l/-c/-C, where it's the -p period up to 2000 ms)\n");
+    fprintf(out, "       --check-source discard replies not from target address\n");
     fprintf(out, "\n");
     fprintf(out, "Output options:\n");
     fprintf(out, "   -a, --alive        show targets that are alive\n");


### PR DESCRIPTION
Using the new option --check-source discards Echo reply packets sourced from an address that is different from the specified target address.  This can be useful on busy monitoring hosts, because it is possible that two fping processes running at he same time use the same ICMP Echo Reply Identifier for ICMP Echo messages sent to different hosts.

This aims to address GH issue #206.