### PR TITLE
new option --check-source

### DIFF
--- a/ci/test-02-help.pl
+++ b/ci/test-02-help.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 
-use Test::Command tests => 12;
+use Test::Command tests => 15;
 
 my $I_HELP = "   -I, --iface=IFACE  bind to a particular interface\n";
 $I_HELP = '' if $^O eq 'darwin';
@@ -38,3 +38,9 @@ my $cmd3 = Test::Command->new(cmd => "fping -Z");
 $cmd3->exit_is_num(1);
 $cmd3->stdout_is_eq("");
 $cmd3->stderr_like(qr{^fping: (illegal|invalid) option -- '?Z'?\nsee 'fping -h' for usage information\n$});
+
+# fping with unknown long option
+my $cmd5 = Test::Command->new(cmd => "fping --unknown-long-option");
+$cmd5->exit_is_num(1);
+$cmd5->stdout_is_eq("");
+$cmd5->stderr_like(qr{^fping: (illegal|invalid) option -- '?unknown-long-option'?\nsee 'fping -h' for usage information\n$});

--- a/doc/fping.pod
+++ b/doc/fping.pod
@@ -81,6 +81,13 @@ shows the response time in milliseconds for each of the five requests, with the
 C<-> indicating that no response was received to the fourth request.  This
 option overrides B<-a> or B<-u>.
 
+=item B<--check-source>
+
+Discard Echo replies that are sourced from a different address than the target
+address. This avoids spurious reachability results on busy monitoring systems
+where two B<fping> instances with the same lower 16 bits of the process ID may
+be running at the same time.
+
 =item B<-d>, B<--rdns>
 
 Use DNS to lookup address of ping target. This allows you to give fping


### PR DESCRIPTION
Using the new option --check-source discards Echo reply packets sourced from an address that is different from the specified target address.  This can be useful on busy monitoring hosts, because it is possible that two fping processes running at he same time use the same ICMP Echo Reply Identifier for ICMP Echo messages sent to different hosts.

This aims to address GH issue #206.