### PR TITLE
Document that -a and -u are overridden by -c and -C

### DIFF
--- a/doc/fping.pod
+++ b/doc/fping.pod
@@ -36,7 +36,7 @@ Restrict name resolution and IPs to IPv6 addresses.
 
 =item B<-a>, B<--alive>
 
-Show systems that are alive.
+Show systems that are alive.  (Options B<-c> and B<-C> override B<-a>.)
 
 =item B<-A>, B<--addr>
 
@@ -248,7 +248,7 @@ Ignored (for compatibility with fping 2.4).
 
 =item B<-u>, B<--unreach>
 
-Show targets that are unreachable.
+Show targets that are unreachable.  (Options B<-c> and B<-C> override B<-u>.)
 
 =item B<-v>, B<--version>
 


### PR DESCRIPTION
The other way around was already documented in commit ae0bc2380462878466f19aa45c7d38774f4b6e3f, but GitHub pull request #337 by Moritz Lenz implies that this is insufficient.