### PR TITLE
Another batch of additional tests

### DIFF
--- a/ci/test-01-basics.pl
+++ b/ci/test-01-basics.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 
-use Test::Command tests => 12;
+use Test::Command tests => 15;
 use Test::More;
 
 # ping 127.0.0.1
@@ -44,4 +44,12 @@ SKIP: {
 127\.0\.0\.1 : \[2\], 64 bytes, \d\.\d+ ms \(\d\.\d+ avg, 0% loss\)
 });
     $cmd->stderr_like(qr{127\.0\.0\.1 : \d\.\d+ \d\.\d+ \d\.\d+\n});
+}
+
+# invalid target name
+{
+    my $cmd = Test::Command->new(cmd => "fping host.name.invalid");
+    $cmd->exit_is_num(2);
+    $cmd->stdout_is_eq("");
+    $cmd->stderr_like(qr{host\.name\.invalid: .+\n});
 }

--- a/ci/test-05-options-c-e.pl
+++ b/ci/test-05-options-c-e.pl
@@ -1,11 +1,12 @@
 #!/usr/bin/perl -w
 
-use Test::Command tests => 69;
+use Test::Command tests => 72;
 use Test::More;
 
 #  -c n           count of pings to send to each target (default 1)
 #  -C n           same as -c, report results in verbose format
 #  --check-source discard replies not from target address
+#  -d             reverse name lookup
 #  -D             print timestamp before each output line
 #  -e             show elapsed time on return packets
 
@@ -195,6 +196,14 @@ ff02::1   : \[0\], timed out \(NaN avg, 100% loss\)
 127\.0\.0\.1 : \d\.\d+
 ff02::1   : -
 });
+}
+
+# fping -d
+{
+my $cmd = Test::Command->new(cmd => "fping -d 127.0.0.1");
+$cmd->exit_is_num(0);
+$cmd->stdout_is_eq("localhost is alive\n");
+$cmd->stderr_is_eq("");
 }
 
 # fping -D

--- a/ci/test-05-options-c-e.pl
+++ b/ci/test-05-options-c-e.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 
-use Test::Command tests => 63;
+use Test::Command tests => 69;
 use Test::More;
 
 #  -c n           count of pings to send to each target (default 1)
@@ -62,6 +62,15 @@ localhost : \[1\], 64 bytes, \d\.\d+ ms \(\d\.\d+ avg, 0% loss\)
 $cmd->stderr_like(qr{localhost : xmt/rcv/%loss = 2/2/0%, min/avg/max = \d\.\d+/\d\.\d+/\d\.\d+
 127\.0\.0\.1 : xmt/rcv/%loss = 2/2/0%, min/avg/max = \d\.\d+/\d\.\d+/\d\.\d+
 });
+}
+
+# fping -c n ff02::1
+{
+my $cmd = Test::Command->new(cmd => "fping -c 1 ff02::1");
+$cmd->exit_is_num(0);
+$cmd->stdout_like(qr{ff02::1 : \[0\], 64 bytes, \d\.\d+ ms \(\d\.\d+ avg, 0% loss\)\n});
+$cmd->stderr_like(qr{ \[<- .*\]
+ff02::1 : xmt/rcv/%loss = 1/1/0%, min/avg/max = \d\.\d+/\d\.\d+/\d\.\d+\n});
 }
 
 # fping -C n
@@ -126,6 +135,15 @@ $cmd->stdout_is_eq("");
 $cmd->stderr_like(qr{127\.0\.0\.1 :( \d\.\d+){20}
 127\.0\.0\.2 :( \d\.\d+){20}
 });
+}
+
+# fping -C n ff02::1
+{
+my $cmd = Test::Command->new(cmd => "fping -C 1 ff02::1");
+$cmd->exit_is_num(0);
+$cmd->stdout_like(qr{ff02::1 : \[0\], 64 bytes, \d\.\d+ ms \(\d\.\d+ avg, 0% loss\)\n});
+$cmd->stderr_like(qr{ \[<- .*\]
+ff02::1 : \d\.\d+\n});
 }
 
 # fping --check-source

--- a/ci/test-08-options-n-q.pl
+++ b/ci/test-08-options-n-q.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 
-use Test::Command tests => 39;
+use Test::Command tests => 42;
 
 #  -n         show targets by name (-d is equivalent)
 #  -O n       set the type of service (tos) flag on the ICMP packets
@@ -53,6 +53,15 @@ $cmd->stderr_is_eq("");
 my $cmd = Test::Command->new(cmd => "fping -O 2 --print-tos 127.0.0.1");
 $cmd->exit_is_num(0);
 $cmd->stdout_like(qr{127\.0\.0\.1 is alive \(TOS \d+\)
+});
+$cmd->stderr_is_eq("");
+}
+
+# fping --print-tos
+{
+my $cmd = Test::Command->new(cmd => "fping --print-tos 127.0.0.1");
+$cmd->exit_is_num(0);
+$cmd->stdout_like(qr{127\.0\.0\.1 is alive \(TOS 0\)
 });
 $cmd->stderr_is_eq("");
 }

--- a/ci/test-08-options-n-q.pl
+++ b/ci/test-08-options-n-q.pl
@@ -1,6 +1,7 @@
 #!/usr/bin/perl -w
 
-use Test::Command tests => 42;
+use Test::Command tests => 45;
+use Test::More;
 
 #  -n         show targets by name (-d is equivalent)
 #  -O n       set the type of service (tos) flag on the ICMP packets
@@ -64,6 +65,17 @@ $cmd->exit_is_num(0);
 $cmd->stdout_like(qr{127\.0\.0\.1 is alive \(TOS 0\)
 });
 $cmd->stderr_is_eq("");
+}
+
+# fping --print-tos with IPv6
+SKIP: {
+    if($ENV{SKIP_IPV6}) {
+        skip 'Skip IPv6 tests', 3;
+    }
+    my $cmd = Test::Command->new(cmd => "fping --print-tos ::1");
+    $cmd->exit_is_num(0);
+    $cmd->stdout_like(qr{::1 is alive \(TOS unknown\)\n});
+    $cmd->stderr_is_eq("");
 }
 
 # fping -q

--- a/ci/test-09-option-r-t.pl
+++ b/ci/test-09-option-r-t.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 
-use Test::Command tests => 27;
+use Test::Command tests => 30;
 use Test::More;
 
 #  -R         random bytes
@@ -67,6 +67,30 @@ $cmd->stderr_like(qr{\s*
 \s*1 timeouts \(waiting for response\)
 \s*1 ICMP Echos sent
 \s*0 ICMP Echo Replies received
+\s*0 other ICMP received
+
+\s*\d\.\d+ ms \(min round trip time\)
+\s*\d\.\d+ ms \(avg round trip time\)
+\s*\d\.\d+ ms \(max round trip time\)
+\s*\d\.\d+ sec \(elapsed real time\)
+});
+}
+
+# fping -s (both valid and invalid host name)
+{
+my $cmd = Test::Command->new(cmd => "fping -s 127.0.0.1 host.name.invalid");
+$cmd->exit_is_num(2);
+$cmd->stdout_is_eq("127.0.0.1 is alive\n");
+$cmd->stderr_like(qr{host\.name\.invalid: .+
+\s*
+\s*1 targets
+\s*1 alive
+\s*0 unreachable
+\s*1 unknown addresses
+\s*
+\s*0 timeouts \(waiting for response\)
+\s*1 ICMP Echos sent
+\s*1 ICMP Echo Replies received
 \s*0 other ICMP received
 
 \s*\d\.\d+ ms \(min round trip time\)

--- a/ci/test-11-unpriv.pl
+++ b/ci/test-11-unpriv.pl
@@ -38,7 +38,7 @@ sub test_unprivileged_works {
     plan tests => 3;
 
     {
-        my $cmd = Test::Command->new(cmd => "fping 127.0.0.1");
+        my $cmd = Test::Command->new(cmd => "/tmp/fping.copy 127.0.0.1");
         $cmd->exit_is_num(0);
         $cmd->stdout_is_eq("127.0.0.1 is alive\n");
         $cmd->stderr_is_eq("");

--- a/ci/test-11-unpriv.pl
+++ b/ci/test-11-unpriv.pl
@@ -35,12 +35,18 @@ else {
 }
 
 sub test_unprivileged_works {
-    plan tests => 3;
+    plan tests => 6;
 
     {
         my $cmd = Test::Command->new(cmd => "/tmp/fping.copy 127.0.0.1");
         $cmd->exit_is_num(0);
         $cmd->stdout_is_eq("127.0.0.1 is alive\n");
+        $cmd->stderr_is_eq("");
+    }
+    {
+        my $cmd = Test::Command->new(cmd => "/tmp/fping.copy --print-tos 127.0.0.1");
+        $cmd->exit_is_num(0);
+        $cmd->stdout_is_eq("127.0.0.1 is alive (TOS unknown)\n");
         $cmd->stderr_is_eq("");
     }
 }


### PR DESCRIPTION
* fix test of unprivileged use
* test `--print-tos` output with IPv4 datagram socket
* test `--print-tos` output with IPv6
* test `--print-tos` output without `-O`
* test `-c` and `-C` with reply source address different from target address (using `ff02::1`)
* test `-d` a little, since it may be mostly equivalent to `-n`, but still uses different code paths
* test error message and statistics output when name resolution does not provide an IP address

This has been tested on GNU/Linux. I do not know if it also works on macOS.