### PR TITLE
Increase maximum -s value to 65507

### DIFF
--- a/ci/test-03-forbidden.pl
+++ b/ci/test-03-forbidden.pl
@@ -38,11 +38,11 @@ $cmd7->exit_is_num(1);
 $cmd7->stdout_is_eq("");
 $cmd7->stderr_is_eq("fping: specify only one of c, l\n");
 
-# fping -b 65509
-my $cmd8 = Test::Command->new(cmd => "fping -b 65509 127.0.0.1");
+# fping -b 65508
+my $cmd8 = Test::Command->new(cmd => "fping -b 65508 127.0.0.1");
 $cmd8->exit_is_num(1);
 $cmd8->stdout_is_eq("");
-$cmd8->stderr_is_eq("fping: data size 65509 not valid, must be lower than 65488\n");
+$cmd8->stderr_is_eq("fping: data size 65508 not valid, must not be larger than 65507\n");
 
 # fping -B 0.9
 my $cmd9 = Test::Command->new(cmd => "fping -B 0.9 127.0.0.1");

--- a/src/fping.c
+++ b/src/fping.c
@@ -134,8 +134,8 @@ extern int h_errno;
 
 /*** Ping packet defines ***/
 
-#define MAX_IP_PACKET 65536 /* (theoretical) max IP packet size */
-#define SIZE_IP_HDR 40
+#define MAX_IP_PACKET 65535 /* (theoretical) max IPv4 packet size */
+#define SIZE_IP_HDR 20 /* min IPv4 header size */
 #define SIZE_ICMP_HDR 8 /* from ip_icmp.h */
 #define MAX_PING_DATA (MAX_IP_PACKET - SIZE_IP_HDR - SIZE_ICMP_HDR)
 
@@ -952,7 +952,7 @@ int main(int argc, char **argv)
 #endif
 
     if (ping_data_size > MAX_PING_DATA) {
-        fprintf(stderr, "%s: data size %u not valid, must be lower than %u\n",
+        fprintf(stderr, "%s: data size %u not valid, must not be larger than %u\n",
             prog, ping_data_size, (unsigned int)MAX_PING_DATA);
         exit(1);
     }


### PR DESCRIPTION
Correct definitions: maximum theoretical IPv4 packet size and minimum IPv4 header size (previously probably IPv6 size was used).

Because fping does not know ahead whether address is IPv4 or IPv6 assume IPv4. Previously fping allowed only `65488`, but real maximum for IPv4 on Linux is `65507` (IPv6 would allow `65527`).