### PR TITLE
allow combination of -a with --print-tos

### DIFF
--- a/ci/test-05-options-c-e.pl
+++ b/ci/test-05-options-c-e.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 
-use Test::Command tests => 72;
+use Test::Command tests => 75;
 use Test::More;
 
 #  -c n           count of pings to send to each target (default 1)
@@ -292,6 +292,14 @@ my $cmd = Test::Command->new(cmd => "fping -e 127.0.0.1");
 $cmd->exit_is_num(0);
 $cmd->stdout_like(qr{127\.0\.0\.1 is alive \(\d\.\d+ ms\)
 });
+$cmd->stderr_is_eq("");
+}
 
+# fping -e -a
+{
+my $cmd = Test::Command->new(cmd => "fping -e -a 127.0.0.1");
+$cmd->exit_is_num(0);
+$cmd->stdout_like(qr{127\.0\.0\.1 \(\d\.\d+ ms\)
+});
 $cmd->stderr_is_eq("");
 }

--- a/ci/test-08-options-n-q.pl
+++ b/ci/test-08-options-n-q.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 
-use Test::Command tests => 45;
+use Test::Command tests => 48;
 use Test::More;
 
 #  -n         show targets by name (-d is equivalent)
@@ -54,6 +54,15 @@ $cmd->stderr_is_eq("");
 my $cmd = Test::Command->new(cmd => "fping -O 2 --print-tos 127.0.0.1");
 $cmd->exit_is_num(0);
 $cmd->stdout_like(qr{127\.0\.0\.1 is alive \(TOS \d+\)
+});
+$cmd->stderr_is_eq("");
+}
+
+# fping -a -O --print-tos
+{
+my $cmd = Test::Command->new(cmd => "fping -a -O 32 --print-tos 127.0.0.1");
+$cmd->exit_is_num(0);
+$cmd->stdout_like(qr{127\.0\.0\.1 \(TOS \d+\)
 });
 $cmd->stderr_is_eq("");
 }

--- a/src/fping.c
+++ b/src/fping.c
@@ -2518,16 +2518,16 @@ int wait_for_reply(int64_t wait_time)
         if (verbose_flag || alive_flag) {
             printf("%s", h->host);
 
-            if (verbose_flag) {
+            if (verbose_flag)
                 printf(" is alive");
-                  if(print_tos_flag) {
-                      if(ip_header_tos != -1) {
-                          printf(" (TOS %d)", ip_header_tos);
-                      }
-                      else {
-                          printf(" (TOS unknown)");
-                      }
-                  }
+
+            if(print_tos_flag) {
+                if(ip_header_tos != -1) {
+                    printf(" (TOS %d)", ip_header_tos);
+                }
+                else {
+                    printf(" (TOS unknown)");
+                }
             }
 
             if (print_ttl_flag) {
@@ -3108,7 +3108,7 @@ void usage(int is_error)
     fprintf(out, "   -v, --version      show version\n");
     fprintf(out, "   -x, --reachable=N  shows if >=N hosts are reachable or not\n");
     fprintf(out, "   -X, --fast-reachable=N exits true immediately when N hosts are found\n");
-    fprintf(out, "       --print-tos    show tos value\n");
+    fprintf(out, "       --print-tos    show received TOS value\n");
     fprintf(out, "       --print-ttl    show IP TTL value\n");
     exit(is_error);
 }


### PR DESCRIPTION
This is similar to how -e, --elapsed works.
Also adjust -h output regarding --print-tos.

(This conflicts with pull request #345 (I think), therefore only as a draft PR for now.)