### PR TITLE
Fix warning unused parameter 'reply_timestamp' under macOS

### DIFF
--- a/src/fping.c
+++ b/src/fping.c
@@ -2024,7 +2024,11 @@ select_again:
 }
 
 int receive_packet(int64_t wait_time,
+#if HAVE_SO_TIMESTAMPNS
     int64_t *reply_timestamp,
+#else
+    int64_t *reply_timestamp __attribute__((unused)),
+#endif
     struct sockaddr *reply_src_addr,
     size_t reply_src_addr_len,
     char *reply_buf,


### PR DESCRIPTION
Under macOS the following build warning is fixed

```
gcc -DHAVE_CONFIG_H -I. -I..    -Wall -Wextra -Wno-sign-compare -DIPV6 -g -O0 -fprofile-arcs -ftest-coverage -MT fping-fping.o -MD -MP -MF .deps/fping-fping.Tpo -c -o fping-fping.o `test -f 'fping.c' || echo './'`fping.c
fping.c:2027:14: warning: unused parameter 'reply_timestamp' [-Wunused-parameter]
    int64_t *reply_timestamp,
             ^
1 warning generated.
```