### PR TITLE
Dockerfile support architekture 386 change distribution from ubuntu to debian

### DIFF
--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -1,9 +1,10 @@
-FROM ubuntu:20.04
+FROM debian:stable
 
 # Base
 RUN apt-get update && apt-get install -y \
   build-essential \
   automake \
+  autoconf \
   m4
 
 # Add source code


### PR DESCRIPTION
The change of the Dockerfile from the distribution ubuntu to debian is for the support of the system architecture i386.
Successful test with podman `podman build -t fping -f contrib/Dockerfile .`