### PR TITLE
Add feature: support ICMP type 13/14 timestamps

### DIFF
--- a/ci/test-04-options-a-b.pl
+++ b/ci/test-04-options-a-b.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 
-use Test::Command tests => 41;
+use Test::Command tests => 44;
 use Test::More;
 use Time::HiRes qw(gettimeofday tv_interval);
 
@@ -81,6 +81,14 @@ $cmd->stderr_is_eq("");
 my $cmd = Test::Command->new(cmd => "fping --print-ttl 127.0.0.1");
 $cmd->exit_is_num(0);
 $cmd->stdout_like(qr{127\.0\.0\.1 is alive \(TTL \d+\)});
+$cmd->stderr_is_eq("");
+}
+
+# fping --icmp-timestamp
+{
+my $cmd = Test::Command->new(cmd => "fping --icmp-timestamp 127.0.0.1");
+$cmd->exit_is_num(0);
+$cmd->stdout_like(qr{127\.0\.0\.1 is alive \(Timestamp Originate=\d+ Receive=\d+ Transmit=\d+\)});
 $cmd->stderr_is_eq("");
 }
 

--- a/ci/test-05-options-c-e.pl
+++ b/ci/test-05-options-c-e.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 
-use Test::Command tests => 75;
+use Test::Command tests => 78;
 use Test::More;
 
 #  -c n           count of pings to send to each target (default 1)
@@ -75,6 +75,22 @@ SKIP: {
     $cmd->stdout_like(qr{ff02::1 : \[0\], 64 bytes, \d\.\d+ ms \(\d\.\d+ avg, 0% loss\)\n});
     $cmd->stderr_like(qr{ \[<- .*\]
 ff02::1 : xmt/rcv/%loss = 1/1/0%, min/avg/max = \d\.\d+/\d\.\d+/\d\.\d+\n});
+}
+
+# fping --icmp-timestamp -c n 127.0.0.1
+{
+my $cmd = Test::Command->new(cmd => "fping -4 --icmp-timestamp -c 2 127.0.0.1");
+$cmd->exit_is_num(0);
+$cmd->stdout_like(qr{127\.0\.0\.1 : \[0\], 20 bytes, \d\.\d+ ms \(\d\.\d+ avg, 0% loss\)
+ICMP timestamp: Originate=\d+ Receive=\d+ Transmit=\d+
+ICMP timestamp RTT tsrtt=\d+
+127\.0\.0\.1 : \[1\], 20 bytes, \d\.\d+ ms \(\d\.\d+ avg, 0% loss\)
+ICMP timestamp: Originate=\d+ Receive=\d+ Transmit=\d+
+ICMP timestamp RTT tsrtt=\d+
+});
+
+$cmd->stderr_like(qr{127\.0\.0\.1 : xmt/rcv/%loss = 2/2/0%, min/avg/max = \d\.\d+/\d\.\d+/\d\.\d+
+});
 }
 
 # fping -C n

--- a/src/fping.h
+++ b/src/fping.h
@@ -28,7 +28,7 @@ extern int random_data_flag;
 int  open_ping_socket_ipv4(int *socktype);
 void init_ping_buffer_ipv4(size_t ping_data_size);
 void socket_set_src_addr_ipv4(int s, struct in_addr *src_addr, int *ident);
-int  socket_sendto_ping_ipv4(int s, struct sockaddr *saddr, socklen_t saddr_len, uint16_t icmp_seq, uint16_t icmp_id);
+int  socket_sendto_ping_ipv4(int s, struct sockaddr *saddr, socklen_t saddr_len, uint16_t icmp_seq, uint16_t icmp_id, uint8_t icmp_proto);
 #ifdef IPV6
 int  open_ping_socket_ipv6(int *socktype);
 void init_ping_buffer_ipv6(size_t ping_data_size);


### PR DESCRIPTION
This is a development branch. (Issues: #265)

The current version has no output yet, but can be tested with GDP. Please note that root rights are required for icmp type 13 queries

**Build**
```
./autogen.sh
./configure --enable-debug
make CFLAGS="-g -O0 -fprofile-arcs -ftest-coverage"
```

**GDB Usage**
```
gdb fping
set args --icmp-timestamp 127.0.0.1
break fping.c:2289

print *icp
```