### PR TITLE
Add feature: support ICMP type 13/14 timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+Next
+====
+
+## New features
+
+- New option --icmp-timestamp send ICMP timestamp requests (ICMP type 13)
+  instead of ICMP Echo requests (#353, thanks @auerswal and @gsnw-sebast)
+
+
 fping 5.2 (2024-04-21)
 ======================
 

--- a/ci/test-04-options-a-b.pl
+++ b/ci/test-04-options-a-b.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 
-use Test::Command tests => 41;
+use Test::Command tests => 44;
 use Test::More;
 use Time::HiRes qw(gettimeofday tv_interval);
 
@@ -81,6 +81,17 @@ $cmd->stderr_is_eq("");
 my $cmd = Test::Command->new(cmd => "fping --print-ttl 127.0.0.1");
 $cmd->exit_is_num(0);
 $cmd->stdout_like(qr{127\.0\.0\.1 is alive \(TTL \d+\)});
+$cmd->stderr_is_eq("");
+}
+
+# fping --icmp-timestamp
+SKIP: {
+if($^O eq 'darwin') {
+    skip 'On macOS, this test is unreliable', 3;
+}
+my $cmd = Test::Command->new(cmd => "fping --icmp-timestamp 127.0.0.1");
+$cmd->exit_is_num(0);
+$cmd->stdout_like(qr{127\.0\.0\.1 is alive \(Timestamp Originate=\d+ Receive=\d+ Transmit=\d+\)});
 $cmd->stderr_is_eq("");
 }
 

--- a/ci/test-04-options-a-b.pl
+++ b/ci/test-04-options-a-b.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 
-use Test::Command tests => 44;
+use Test::Command tests => 47;
 use Test::More;
 use Time::HiRes qw(gettimeofday tv_interval);
 
@@ -120,6 +120,14 @@ my $cmd = Test::Command->new(cmd => "fping -b 1000 127.0.0.1");
 $cmd->exit_is_num(0);
 $cmd->stdout_is_eq("127.0.0.1 is alive\n");
 $cmd->stderr_is_eq("");
+}
+
+# fping --icmp-timestamp -b
+{
+my $cmd = Test::Command->new(cmd => "fping --icmp-timestamp -b 1000 127.0.0.1");
+$cmd->exit_is_num(1);
+$cmd->stdout_is_eq("");
+$cmd->stderr_like(qr{Usage:});
 }
 
 # fping -B

--- a/ci/test-05-options-c-e.pl
+++ b/ci/test-05-options-c-e.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 
-use Test::Command tests => 75;
+use Test::Command tests => 78;
 use Test::More;
 
 #  -c n           count of pings to send to each target (default 1)
@@ -75,6 +75,25 @@ SKIP: {
     $cmd->stdout_like(qr{ff02::1 : \[0\], 64 bytes, \d\.\d+ ms \(\d\.\d+ avg, 0% loss\)\n});
     $cmd->stderr_like(qr{ \[<- .*\]
 ff02::1 : xmt/rcv/%loss = 1/1/0%, min/avg/max = \d\.\d+/\d\.\d+/\d\.\d+\n});
+}
+
+# fping --icmp-timestamp -c n 127.0.0.1
+SKIP: {
+if($^O eq 'darwin') {
+    skip 'On macOS, this test is unreliable', 3;
+}
+my $cmd = Test::Command->new(cmd => "fping -4 --icmp-timestamp -c 2 127.0.0.1");
+$cmd->exit_is_num(0);
+$cmd->stdout_like(qr{127\.0\.0\.1 : \[0\], 20 bytes, \d\.\d+ ms \(\d\.\d+ avg, 0% loss\)
+ICMP timestamp: Originate=\d+ Receive=\d+ Transmit=\d+
+ICMP timestamp RTT tsrtt=\d+
+127\.0\.0\.1 : \[1\], 20 bytes, \d\.\d+ ms \(\d\.\d+ avg, 0% loss\)
+ICMP timestamp: Originate=\d+ Receive=\d+ Transmit=\d+
+ICMP timestamp RTT tsrtt=\d+
+});
+
+$cmd->stderr_like(qr{127\.0\.0\.1 : xmt/rcv/%loss = 2/2/0%, min/avg/max = \d\.\d+/\d\.\d+/\d\.\d+
+});
 }
 
 # fping -C n

--- a/ci/test-05-options-c-e.pl
+++ b/ci/test-05-options-c-e.pl
@@ -84,12 +84,8 @@ if($^O eq 'darwin') {
 }
 my $cmd = Test::Command->new(cmd => "fping -4 --icmp-timestamp -c 2 127.0.0.1");
 $cmd->exit_is_num(0);
-$cmd->stdout_like(qr{127\.0\.0\.1 : \[0\], 20 bytes, \d\.\d+ ms \(\d\.\d+ avg, 0% loss\)
-ICMP timestamp: Originate=\d+ Receive=\d+ Transmit=\d+
-ICMP timestamp RTT tsrtt=\d+
-127\.0\.0\.1 : \[1\], 20 bytes, \d\.\d+ ms \(\d\.\d+ avg, 0% loss\)
-ICMP timestamp: Originate=\d+ Receive=\d+ Transmit=\d+
-ICMP timestamp RTT tsrtt=\d+
+$cmd->stdout_like(qr{127\.0\.0\.1 : \[0\], 20 bytes, \d\.\d+ ms \(\d\.\d+ avg, 0% loss\), ICMP timestamp: Originate=\d+ Receive=\d+ Transmit=\d+
+127\.0\.0\.1 : \[1\], 20 bytes, \d\.\d+ ms \(\d\.\d+ avg, 0% loss\), ICMP timestamp: Originate=\d+ Receive=\d+ Transmit=\d+
 });
 
 $cmd->stderr_like(qr{127\.0\.0\.1 : xmt/rcv/%loss = 2/2/0%, min/avg/max = \d\.\d+/\d\.\d+/\d\.\d+

--- a/doc/fping.pod
+++ b/doc/fping.pod
@@ -157,8 +157,8 @@ Set the interface (requires SO_BINDTODEVICE support).
 
 =item B<--icmp-timestamp>
 
-Send ICMP timestamp requests (ICMP type 13).
-If B<fping> not recive ICMP timestamp reply, "(Timestamp unknown)" is returned.
+Send ICMP timestamp requests (ICMP type 13) instead of ICMP Echo requests.
+Cannot be used together with B<-b> because ICMP timestamp messages have a fixed size.
 IPv4 only, requires root privileges.
 
 =item B<-k>, B<--fwmark>=I<FWMARK>

--- a/doc/fping.pod
+++ b/doc/fping.pod
@@ -155,6 +155,12 @@ to any target (default is 10, minimum is 1).
 
 Set the interface (requires SO_BINDTODEVICE support).
 
+=item B<--icmp-timestamp>
+
+Send ICMP timestamp requests (ICMP type 13).
+If B<fping> not recive ICMP timestamp reply, "(Timestamp unknown)" is returned.
+IPv4 only, requires root privileges.
+
 =item B<-k>, B<--fwmark>=I<FWMARK>
 
 Set FWMARK on ping packets for policy-based routing. Requires Linux kernel

--- a/src/fping.c
+++ b/src/fping.c
@@ -1939,7 +1939,7 @@ int send_ping(HOST_ENTRY *h, int index)
 
     if (h->saddr.ss_family == AF_INET && socket4 >= 0) {
         if(icmp_request_typ == 13)
-            proto = 13;
+            proto = ICMP_TSTAMP;
         n = socket_sendto_ping_ipv4(socket4, (struct sockaddr *)&h->saddr, h->saddr_len, myseq, ident4, proto);
     }
 #ifdef IPV6
@@ -2216,7 +2216,7 @@ int decode_icmp_ipv4(
 
     icp = (struct icmp *)(reply_buf + hlen);
 
-    if (icp->icmp_type != ICMP_ECHOREPLY && icp->icmp_type != 14) {
+    if (icp->icmp_type != ICMP_ECHOREPLY && icp->icmp_type != ICMP_TSTAMPREPLY) {
         /* Handle other ICMP packets */
         struct icmp *sent_icmp;
         SEQMAP_VALUE *seqmap_value;
@@ -2231,7 +2231,7 @@ int decode_icmp_ipv4(
 
         sent_icmp = (struct icmp *)(reply_buf + hlen + ICMP_MINLEN + sizeof(struct ip));
 
-        if ((sent_icmp->icmp_type != ICMP_ECHO && sent_icmp->icmp_type != 13) || sent_icmp->icmp_id != ident4) {
+        if ((sent_icmp->icmp_type != ICMP_ECHO && sent_icmp->icmp_type != ICMP_TSTAMP) || sent_icmp->icmp_id != ident4) {
             /* not caused by us */
             return -1;
         }
@@ -2282,7 +2282,7 @@ int decode_icmp_ipv4(
 
     *id = icp->icmp_id;
     *seq = ntohs(icp->icmp_seq);
-    if(icp->icmp_type == 14) {
+    if(icp->icmp_type == ICMP_TSTAMPREPLY) {
         *ip_header_otime_ms = ntohl(icp->icmp_dun.id_ts.its_otime);
         *ip_header_rtime_ms = ntohl(icp->icmp_dun.id_ts.its_rtime);
         *ip_header_ttime_ms = ntohl(icp->icmp_dun.id_ts.its_ttime);

--- a/src/fping.c
+++ b/src/fping.c
@@ -691,6 +691,8 @@ int main(int argc, char **argv)
         case 'b':
             if (sscanf(optparse_state.optarg, "%u", &ping_data_size) != 1)
                 usage(1);
+            if (icmp_request_typ > 0)
+                usage(1);
 
             break;
 
@@ -3129,7 +3131,7 @@ void usage(int is_error)
     fprintf(out, "   -t, --timeout=MSEC individual target initial timeout (default: %.0f ms,\n", timeout / 1e6);
     fprintf(out, "                      except with -l/-c/-C, where it's the -p period up to 2000 ms)\n");
     fprintf(out, "       --check-source discard replies not from target address\n");
-    fprintf(out, "       --icmp-timestamp send ping type Timestamp Request\n");
+    fprintf(out, "       --icmp-timestamp send ping type Timestamp Request (only if no -b specified)\n");
     fprintf(out, "\n");
     fprintf(out, "Output options:\n");
     fprintf(out, "   -a, --alive        show targets that are alive\n");

--- a/src/fping.c
+++ b/src/fping.c
@@ -2404,7 +2404,6 @@ int wait_for_reply(int64_t wait_time)
     long ip_header_otime_ms = -1;
     long ip_header_rtime_ms = -1;
     long ip_header_ttime_ms = -1;
-    int tsrtt;
 
     /* Receive packet */
     result = receive_packet(wait_time, /* max. wait time, in ns */
@@ -2610,18 +2609,16 @@ int wait_for_reply(int64_t wait_time)
             fprintf(stderr, " [<- %s]", buf);
         }
 
-        printf("\n");
-
         if (icmp_request_typ == 13) {
             if(ip_header_otime_ms != -1 && ip_header_rtime_ms != -1 && ip_header_ttime_ms != -1) {
-                printf("ICMP timestamp: Originate=%lu Receive=%lu Transmit=%lu\n", ip_header_otime_ms, ip_header_rtime_ms, ip_header_ttime_ms);
-                tsrtt = (ip_header_ttime_ms - ip_header_otime_ms) + (this_reply - (ip_header_rtime_ms - ip_header_otime_ms));
-                printf("ICMP timestamp RTT tsrtt=%d\n", tsrtt);
+                printf(", ICMP timestamp: Originate=%lu Receive=%lu Transmit=%lu", ip_header_otime_ms, ip_header_rtime_ms, ip_header_ttime_ms);
             }
             else {
-                printf("ICMP timestamp: unknown\n");
+                printf(", ICMP timestamp: unknown");
             }
         }
+
+        printf("\n");
     }
 
     return 1;

--- a/src/fping.h
+++ b/src/fping.h
@@ -28,7 +28,7 @@ extern int random_data_flag;
 int  open_ping_socket_ipv4(int *socktype);
 void init_ping_buffer_ipv4(size_t ping_data_size);
 void socket_set_src_addr_ipv4(int s, struct in_addr *src_addr, int *ident);
-int  socket_sendto_ping_ipv4(int s, struct sockaddr *saddr, socklen_t saddr_len, uint16_t icmp_seq, uint16_t icmp_id);
+int  socket_sendto_ping_ipv4(int s, struct sockaddr *saddr, socklen_t saddr_len, uint16_t icmp_seq, uint16_t icmp_id, uint8_t icmp_proto);
 #ifdef IPV6
 int  open_ping_socket_ipv6(int *socktype);
 void init_ping_buffer_ipv6(size_t ping_data_size);

--- a/src/socket4.c
+++ b/src/socket4.c
@@ -140,7 +140,7 @@ int socket_sendto_ping_ipv4(int s, struct sockaddr* saddr, socklen_t saddr_len, 
     icp = (struct icmp*)ping_buffer_ipv4;
 
     icp->icmp_type = icmp_proto;
-    if(icmp_proto == 13) {
+    if(icmp_proto == ICMP_TSTAMP) {
         clock_gettime(CLOCK_REALTIME, &tsorig);
         tsorig_ms = (tsorig.tv_sec % (24*60*60)) * 1000 + tsorig.tv_nsec / 1000000;
         icp->icmp_otime = htonl(tsorig_ms);


### PR DESCRIPTION
This is an extension to send ICMP type 13 and receive ICMP type 14 with fping (Issue: #265).
To use it, root rights are required on the system and it can be used as follows.

1. `./fping --icmp-timestamp 127.0.0.1`
```
127.0.0.1 is alive (Timestamp Originate=67895434 Receive=67895434 Transmit=67895434)
```
2. `./fping --icmp-timestamp -c 2 127.0.0.1` (For the output, I first partly oriented myself on hping3)
```
27.0.0.1 : [0], 20 bytes, 0.072 ms (0.072 avg, 0% loss)
ICMP timestamp: Originate=67951889 Receive=67951889 Transmit=67951889
ICMP timestamp RTT tsrtt=71991
127.0.0.1 : [1], 20 bytes, 0.057 ms (0.064 avg, 0% loss)
ICMP timestamp: Originate=67952890 Receive=67952890 Transmit=67952890
ICMP timestamp RTT tsrtt=56783

127.0.0.1 : xmt/rcv/%loss = 2/2/0%, min/avg/max = 0.057/0.064/0.072
``` 

Unfortunately I could not test the function under macOS and the Github Action Test under macOS is not possible.