### PR TITLE
ci: Upgrade actions/upload-artifact to v3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,7 +102,7 @@ jobs:
           ci/build-4-compile.sh
           ci/test-tarball.sh
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: dist
           path: fping-*.tar.gz


### PR DESCRIPTION
This fixes error in CI:
> Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v2.`