### PR TITLE
ping: Add support for IPv4-mapped IPv6 address format

### DIFF
--- a/ci/test-01-basics.pl
+++ b/ci/test-01-basics.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 
-use Test::Command tests => 15;
+use Test::Command tests => 18;
 use Test::More;
 
 # ping 127.0.0.1
@@ -33,6 +33,18 @@ SKIP: {
     $cmd->exit_is_num(0);
     $cmd->stdout_is_eq("ff02::1 is alive\n");
     $cmd->stderr_like(qr{ \[<- .*\]});
+}
+
+# ping ::ffff:127.0.0.1
+SKIP: {
+    if($ENV{SKIP_IPV6}) {
+        skip 'Skip IPv6 tests', 3;
+    }
+    my $cmd = Test::Command->new(cmd => "fping ::ffff:127.0.0.1");
+    $cmd->exit_is_num(0);
+    $cmd->stdout_is_eq("IPv4-Mapped-in-IPv6 address, using IPv4 127.0.0.1
+127.0.0.1 is alive\n");
+    $cmd->stderr_like(qr{ \[<- 127.0.0.1\]});
 }
 
 # ping 3 times 127.0.0.1

--- a/src/fping.c
+++ b/src/fping.c
@@ -1208,6 +1208,14 @@ int main(int argc, char **argv)
          * for each of them */
         for (cursor = event_queue_ping.first; cursor; cursor = cursor->ev_next) {
             table[i] = cursor->host;
+
+            struct in6_addr a6;
+            if (inet_pton(AF_INET6, cursor->host->host, &a6) && IN6_IS_ADDR_V4MAPPED(&a6)) {
+                cursor->host->host = strrchr(cursor->host->host, ':') + 1;
+                cursor->host->saddr.ss_family = AF_INET;
+                printf("IPv4-Mapped-in-IPv6 address, using IPv4 %s\n", cursor->host->host);
+            }
+
             cursor->host->i = i;
             i++;
         }


### PR DESCRIPTION
IP addresses with ::ffff: prefix are IPv6 addresses which are mapped to IPv4. Therefore ping resulting IPv4 address.

    $ ./src/fping -c1 ::ffff:127.0.0.1
    IPv4-Mapped-in-IPv6 address, using IPv4 127.0.0.1
     [<- 127.0.0.1]127.0.0.1        : [0], 64 bytes, 0.066 ms (0.066 avg, 0% loss)

Based on iputils feature https://github.com/iputils/iputils/commit/8ed7ffc999e2a541e06ee48faf26a323dfe487c2, which I sent also to busybox https://lists.busybox.net/pipermail/busybox/2024-October/090974.html.

NOTE: CI failure is unrelated, addressed in https://github.com/schweikert/fping/pull/355. Once you merge fix I'll rebase to get CI green.