### PR TITLE
Add autotrigger for changes in develop to the azure-pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Next
 - New option --icmp-timestamp send ICMP timestamp requests (ICMP type 13)
   instead of ICMP Echo requests (#353, thanks @auerswal and @gsnw-sebast)
 
+## Bugfixes and other changes
+
+- Azure Pipline only trigger when changes are made in the development branch
+  (#359, thanks @gsnw-sebast)
+- Azure Pipline YAML add docker build (#354, thanks @gsnw-sebast)
 
 fping 5.2 (2024-04-21)
 ======================

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,3 +1,6 @@
+trigger:
+- develop
+
 jobs:
 - job: linux_build
   displayName: Linux Build


### PR DESCRIPTION
This change caused the azure-pipeline to start automatically only when changes were made in the branch develop.
For all other changes, the process must be started manually in azure-pipline.

In addition, CHANGELOG.md was extended for the last two pull requests to the azure-pipeline