### PR TITLE
ci: Upgrade actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,7 +102,7 @@ jobs:
           ci/build-4-compile.sh
           ci/test-tarball.sh
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          name: dist
+          name: dist-${{ github.sha }}
           path: fping-*.tar.gz


### PR DESCRIPTION
actions/upload-artifact@v4 works directly because there is already a distinction in the jobs
Issue: #352 