### PR TITLE
Prepare v5.3 release: CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,40 @@ Next
 ## New features
 
 - New option --icmp-timestamp send ICMP timestamp requests (ICMP type 13)
-  instead of ICMP Echo requests (#353, thanks @auerswal and @gsnw-sebast)
+  instead of ICMP Echo requests (#353 #363, thanks @auerswal and @gsnw-sebast)
+- Print returned TTL value (#354, thanks @nalves599)
+- Print returned TOS value (#335 #346 #347, thanks @auerswal and @gsnw-sebast)
+- New option --check-source (#334, thanks @auerswal)
+- Predefined various timestamp formats (#321, thanks @auerswal and @gsnw-sebast)
 
 ## Bugfixes and other changes
 
+- ci: Upgrade actions/upload-artifact to v4 (#360, thanks @gsnw-sebast)
 - Azure Pipline only trigger when changes are made in the development branch
   (#359, thanks @gsnw-sebast)
+- ci: Upgrade actions/upload-artifact to v3 (#355, thanks @pevik)
 - Azure Pipline YAML add docker build (#354, thanks @gsnw-sebast)
+- Dockerfile support architekture 386 change distribution from ubuntu to
+  debian (#350, thanks @gsnw-sebast)
+- Fix warning unused parameter 'reply_timestamp' under macOS (#348, thanks
+  @gsnw-sebast)
+- Fix increase maximum -s value to 65507 (#344, thanks @pevik)
+- CI: use File::Temp to create temporary directory (#343, thanks @auerswal)
+- Fix -k, --fwmark with setuid fping executable (#342, thanks @auerswal)
+- Another batch of additional tests (take 2) (#341, thanks @auerswal)
+- Document that -a and -u are overridden by -c and -C (#338, thanks @auerswal)
+- Fix macOS build warning sets SEQMAP_TIMEOUT_IN_NSSEQMAP_TIMEOUT_IN_NS as INT64_C
+  (#336, thanks @gsnw-sebast)
+- Fix inconsistent limits for address generation via -g, --generator using either
+  range or CIDR (#331, thanks @auerswal)
+- Some additional tests (#329, thanks @auerswal)
+- ci: skip an unreliable test on macOS (#328, thanks @auerswal)
+- Fix incorrect return-value check for a scanf like function (CWE-253) (#323,
+  thanks @gsnw-sebast)
+- A few more tests to increase code coverage a little bit (#320, thanks @auerswal)
+- Github fix: Change to codeql-action-v2 (#319, thanks @gsnw-sebast)
+- Developer function: Debug with Visual Studio Code (#318, thanks @gsnw-sebast)
+- Print cumulative stats with -Q SECS,cumulative (#315, thanks @auerswal)
 
 fping 5.2 (2024-04-21)
 ======================


### PR DESCRIPTION
Preparation of CHANGELOG.md for the new release v5.3
The last two open pull requests are already included

@schweikert You only have to change the Next to `fping 5.3 (<date>)`