### PR TITLE
adjust ICMP Timestamp output

### DIFF
--- a/ci/test-04-options-a-b.pl
+++ b/ci/test-04-options-a-b.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 
-use Test::Command tests => 62;
+use Test::Command tests => 68;
 use Test::More;
 use Time::HiRes qw(gettimeofday tv_interval);
 
@@ -76,6 +76,17 @@ $cmd->stdout_like(qr{127\.0\.0\.1 \(TTL \d+\)\n127\.0\.0\.2 \(TTL \d+\)\n});
 $cmd->stderr_is_eq("");
 }
 
+# fping -a --icmp-timestamp
+SKIP: {
+if($^O eq 'darwin') {
+    skip 'On macOS, this test is unreliable', 3;
+}
+my $cmd = Test::Command->new(cmd => "fping -a --icmp-timestamp 127.0.0.1");
+$cmd->exit_is_num(0);
+$cmd->stdout_like(qr{127\.0\.0\.1 timestamps: Originate=\d+ Receive=\d+ Transmit=\d+ Localreceive=\d+});
+$cmd->stderr_is_eq("");
+}
+
 # fping --print-ttl
 {
 my $cmd = Test::Command->new(cmd => "fping --print-ttl 127.0.0.1");
@@ -91,7 +102,18 @@ if($^O eq 'darwin') {
 }
 my $cmd = Test::Command->new(cmd => "fping --icmp-timestamp 127.0.0.1");
 $cmd->exit_is_num(0);
-$cmd->stdout_like(qr{127\.0\.0\.1 is alive \(Timestamp Originate=\d+ Receive=\d+ Transmit=\d+ Localreceive=\d+\)});
+$cmd->stdout_like(qr{127\.0\.0\.1 is alive, timestamps: Originate=\d+ Receive=\d+ Transmit=\d+ Localreceive=\d+});
+$cmd->stderr_is_eq("");
+}
+
+# fping --icmp-timestamp --print-tos --print-ttl -e
+SKIP: {
+if($^O eq 'darwin') {
+    skip 'On macOS, this test is unreliable', 3;
+}
+my $cmd = Test::Command->new(cmd => "fping --icmp-timestamp --print-tos --print-ttl -e 127.0.0.1");
+$cmd->exit_is_num(0);
+$cmd->stdout_like(qr{127\.0\.0\.1 is alive, timestamps: Originate=\d+ Receive=\d+ Transmit=\d+ Localreceive=\d+ \(TOS \d+\) \(TTL \d+\) \(\d+(\.\d*)? ms\)});
 $cmd->stderr_is_eq("");
 }
 

--- a/ci/test-05-options-c-e.pl
+++ b/ci/test-05-options-c-e.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 
-use Test::Command tests => 84;
+use Test::Command tests => 87;
 use Test::More;
 
 #  -c n           count of pings to send to each target (default 1)
@@ -99,8 +99,23 @@ if($^O eq 'darwin') {
 }
 my $cmd = Test::Command->new(cmd => "fping -4 --icmp-timestamp -c 2 127.0.0.1");
 $cmd->exit_is_num(0);
-$cmd->stdout_like(qr{127\.0\.0\.1 : \[0\], 20 bytes, \d\.\d+ ms \(\d\.\d+ avg, 0% loss\), ICMP timestamp: Originate=\d+ Receive=\d+ Transmit=\d+ Localreceive=\d+
-127\.0\.0\.1 : \[1\], 20 bytes, \d\.\d+ ms \(\d\.\d+ avg, 0% loss\), ICMP timestamp: Originate=\d+ Receive=\d+ Transmit=\d+ Localreceive=\d+
+$cmd->stdout_like(qr{127\.0\.0\.1 : \[0\], 20 bytes, \d\.\d+ ms \(\d\.\d+ avg, 0% loss\), timestamps: Originate=\d+ Receive=\d+ Transmit=\d+ Localreceive=\d+
+127\.0\.0\.1 : \[1\], 20 bytes, \d\.\d+ ms \(\d\.\d+ avg, 0% loss\), timestamps: Originate=\d+ Receive=\d+ Transmit=\d+ Localreceive=\d+
+});
+
+$cmd->stderr_like(qr{127\.0\.0\.1 : xmt/rcv/%loss = 2/2/0%, min/avg/max = \d\.\d+/\d\.\d+/\d\.\d+
+});
+}
+
+# fping --icmp-timestamp --print-tos --print-ttl -c n 127.0.0.1
+SKIP: {
+if($^O eq 'darwin') {
+    skip 'On macOS, this test is unreliable', 3;
+}
+my $cmd = Test::Command->new(cmd => "fping -4 --icmp-timestamp --print-tos --print-ttl -p 100 -c 2 127.0.0.1");
+$cmd->exit_is_num(0);
+$cmd->stdout_like(qr{127\.0\.0\.1 : \[0\], 20 bytes, \d\.\d+ ms \(\d\.\d+ avg, 0% loss\), timestamps: Originate=\d+ Receive=\d+ Transmit=\d+ Localreceive=\d+ \(TOS \d+\) \(TTL \d+\)
+127\.0\.0\.1 : \[1\], 20 bytes, \d\.\d+ ms \(\d\.\d+ avg, 0% loss\), timestamps: Originate=\d+ Receive=\d+ Transmit=\d+ Localreceive=\d+ \(TOS \d+\) \(TTL \d+\)
 });
 
 $cmd->stderr_like(qr{127\.0\.0\.1 : xmt/rcv/%loss = 2/2/0%, min/avg/max = \d\.\d+/\d\.\d+/\d\.\d+

--- a/doc/fping.pod
+++ b/doc/fping.pod
@@ -158,6 +158,8 @@ Set the interface (requires SO_BINDTODEVICE support).
 =item B<--icmp-timestamp>
 
 Send ICMP timestamp requests (ICMP type 13) instead of ICMP Echo requests.
+Print ICMP timestamps for originate, receive, and transmit, together with
+the local receive time in the same format, in addition to normal output.
 Cannot be used together with B<-b> because ICMP timestamp messages have a fixed size.
 IPv4 only, requires root privileges or cap_net_raw.
 

--- a/src/fping.c
+++ b/src/fping.c
@@ -2605,31 +2605,29 @@ int wait_for_reply(int64_t wait_time)
             fprintf(stderr, " [<- %s]", buf);
         }
 
-            if(print_tos_flag) {
-                if(ip_header_tos != -1) {
-                    printf(" (TOS %d)", ip_header_tos);
-                }
-                else {
-                    printf(" (TOS unknown)");
-                }
-            }
-
-            if (print_ttl_flag) {
-              if(ip_header_ttl != -1) {
-                  printf(" (TTL %d)", ip_header_ttl);
-              }
-              else {
-                  printf(" (TTL unknown)");
-              }
-            }
-
         if (icmp_request_typ == 13) {
-            printf("%simestamp%s Originate=%u Receive=%u Transmit=%u Localreceive=%u%s",
-                   per_recv_flag ? ", ICMP t" : " (T",
-                   per_recv_flag ? ":" : "",
+            printf("%s timestamps: Originate=%u Receive=%u Transmit=%u Localreceive=%u",
+                   alive_flag ? "" : ",",
                    ip_header_otime_ms, ip_header_rtime_ms, ip_header_ttime_ms,
-                   ms_since_midnight_utc(recv_time),
-                   per_recv_flag ? "" : ")");
+                   ms_since_midnight_utc(recv_time));
+        }
+
+        if(print_tos_flag) {
+            if(ip_header_tos != -1) {
+                printf(" (TOS %d)", ip_header_tos);
+            }
+            else {
+                printf(" (TOS unknown)");
+            }
+        }
+
+        if (print_ttl_flag) {
+          if(ip_header_ttl != -1) {
+              printf(" (TTL %d)", ip_header_ttl);
+          }
+          else {
+              printf(" (TTL unknown)");
+          }
         }
 
         if (elapsed_flag && !per_recv_flag)


### PR DESCRIPTION
* print TOS and/or TTL after the timestamps
* use the same output format with and without loop or count modes
* omit the comma in front of the timestamps with -a, --alive
* slightly extend man page description of --icmp-timestamp
* adjust existing ICMP Timestamp tests to output format changes
* add tests for some combinations of --icmp-timestamp with -a, -e, --print-tos, and --print-ttl