### PR TITLE
complete SO_TIMESTAMPNS to SO_TIMESTAMP fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+Next
+====
+
+## Bugfixes and other changes
+
+- Fix fallback to SO\_TIMESTAMP if SO\_TIMESTAMPNS is not available (#375, thanks
+  @auerswal)
+
 fping 5.3 (2025-01-02)
 ======================
 


### PR DESCRIPTION
Commit e8660637ccc3bf2aae163fa7c26216843ae98180 added a fallback from setting the socket option SO_TIMESTAMPNS to setting the socket option SO_TIMESTAMP if the nanosecond timestamp option could not be set.  But it did not add code to also look for the control message related to SO_TIMESTAMP.  Thus microsecond timestamps were requested, but not read.

This commit adds the missing code to read microsecond timestamp control messages.

The problem was reported in GitHub issue #374 by @payload.