### PR TITLE
ci: Change github action unsupported ubuntu-20.04

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-22.04, ubuntu-24.04]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2


### PR DESCRIPTION
This commit changes the unsupported github action ubuntu-20.04 version to the new ubuntu-24.04 version.

### Error message
```
Test-Linux (ubuntu-20.04)
This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15.
```