### PR TITLE
Better Dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ Next
 - Report received ICMPv6 error messages (#391, thanks @auerswal)
 - Suppress duplicate reports in count mode with -q, --quiet or -Q, --squiet
   (#392, thanks @gsnw-sebast and @auerswal)
+- Switch to alpine-based multi-stage Docker build to reduce image size
+  Add OpenContainers-compatible labels (#399)
 
 fping 5.3 (2025-01-02)
 ======================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Next
 - Report received ICMPv6 error messages (#391, thanks @auerswal)
 - Suppress duplicate reports in count mode with -q, --quiet or -Q, --squiet
   (#392, thanks @gsnw-sebast and @auerswal)
-- Switch to alpine-based multi-stage Docker build to reduce image size
+- Switch to alpine-based multi-stage Docker build to reduce image size and improve build performance
   Add OpenContainers-compatible labels (#399)
 
 fping 5.3 (2025-01-02)

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -12,9 +12,12 @@ RUN autoreconf --install && ./configure && make
 
 FROM alpine:3.22.1
 
+# OCI annotations
 LABEL org.opencontainers.image.title="fping" \
+      org.opencontainers.image.authors="fping Community" \
       org.opencontainers.image.description="High performance ping tool" \
-      org.opencontainers.image.source="https://github.com/schweikert/fping"
+      org.opencontainers.image.source="https://github.com/schweikert/fping" \
+      org.opencontainers.image.documentation="https://fping.org/fping.8.html" \
 
 COPY --from=builder /app/src/fping /usr/local/bin/fping
 

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -1,17 +1,22 @@
-FROM debian:stable
+FROM alpine:3.22.1 AS builder
 
-# Base
-RUN apt-get update && apt-get install -y \
-  build-essential \
+RUN apk add --no-cache \
+  build-base \
   automake \
   autoconf \
-  m4
+  m4 \
+  git
 
-# Add source code
 COPY ./ /app
-
-# Compile
 WORKDIR /app
-RUN autoreconf --install
-RUN ./configure && make && make install
+RUN autoreconf --install && ./configure && make
+
+FROM alpine:3.22.1
+
+LABEL org.opencontainers.image.title="fping" \
+      org.opencontainers.image.description="High performance ping tool " \
+      org.opencontainers.image.source="https://github.com/schweikert/fping" \
+
+COPY --from=builder /app/src/fping /usr/local/bin/fping
+
 ENTRYPOINT ["fping"]

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -4,8 +4,7 @@ RUN apk add --no-cache \
   build-base \
   automake \
   autoconf \
-  m4 \
-  git
+  m4
 
 COPY ./ /app
 WORKDIR /app
@@ -15,7 +14,7 @@ FROM alpine:3.22.1
 
 LABEL org.opencontainers.image.title="fping" \
       org.opencontainers.image.description="High performance ping tool " \
-      org.opencontainers.image.source="https://github.com/schweikert/fping" \
+      org.opencontainers.image.source="https://github.com/schweikert/fping"
 
 COPY --from=builder /app/src/fping /usr/local/bin/fping
 

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -13,7 +13,7 @@ RUN autoreconf --install && ./configure && make
 FROM alpine:3.22.1
 
 LABEL org.opencontainers.image.title="fping" \
-      org.opencontainers.image.description="High performance ping tool " \
+      org.opencontainers.image.description="High performance ping tool" \
       org.opencontainers.image.source="https://github.com/schweikert/fping"
 
 COPY --from=builder /app/src/fping /usr/local/bin/fping

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.22.1 AS builder
+FROM alpine:latest AS builder
 
 RUN apk add --no-cache \
   build-base \
@@ -10,16 +10,19 @@ COPY ./ /app
 WORKDIR /app
 RUN autoreconf --install && ./configure && make
 
-FROM alpine:3.22.1
+FROM alpine:latest
 
 # OCI annotations
 LABEL org.opencontainers.image.title="fping" \
       org.opencontainers.image.authors="fping Community" \
       org.opencontainers.image.description="High performance ping tool" \
-      org.opencontainers.image.base.name="docker.io/library/alpine:3.22.1" \
+      org.opencontainers.image.base.name="docker.io/library/alpine:latest" \
       org.opencontainers.image.source="https://github.com/schweikert/fping" \
       org.opencontainers.image.documentation="https://fping.org/fping.8.html"
 
+RUN apk add --no-cache mandoc
+
 COPY --from=builder /app/src/fping /usr/local/bin/fping
+COPY --from=builder /app/doc/fping.8 /usr/share/man/man8/fping.8
 
 ENTRYPOINT ["fping"]

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -16,6 +16,7 @@ FROM alpine:3.22.1
 LABEL org.opencontainers.image.title="fping" \
       org.opencontainers.image.authors="fping Community" \
       org.opencontainers.image.description="High performance ping tool" \
+      org.opencontainers.image.base.name="docker.io/library/alpine:3.22.1" \
       org.opencontainers.image.source="https://github.com/schweikert/fping" \
       org.opencontainers.image.documentation="https://fping.org/fping.8.html"
 

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -17,7 +17,7 @@ LABEL org.opencontainers.image.title="fping" \
       org.opencontainers.image.authors="fping Community" \
       org.opencontainers.image.description="High performance ping tool" \
       org.opencontainers.image.source="https://github.com/schweikert/fping" \
-      org.opencontainers.image.documentation="https://fping.org/fping.8.html" \
+      org.opencontainers.image.documentation="https://fping.org/fping.8.html"
 
 COPY --from=builder /app/src/fping /usr/local/bin/fping
 


### PR DESCRIPTION
Changed Base image to alpine
Added Multi Staging
this causes image size to reduce from 541MB To 8.49MB since base image is much more minimal and extra packages are not copied from previous stage.
Added Labeling

```
# docker build -t fping .


[+] Building 15.0s (11/11) FINISHED                                                                                                                                            docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                     0.0s
 => => transferring dockerfile: 514B                                                                                                                                                     0.0s
 => [internal] load metadata for docker.io/library/alpine:3.22.1                                                                                                                         0.4s
 => [internal] load .dockerignore                                                                                                                                                        0.0s
 => => transferring context: 343B                                                                                                                                                        0.0s
 => [internal] load build context                                                                                                                                                        0.1s
 => => transferring context: 1.08MB                                                                                                                                                      0.1s
 => CACHED [builder 1/5] FROM docker.io/library/alpine:3.22.1@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1                                                    0.0s
 => [builder 2/5] RUN apk add --no-cache   build-base   automake   autoconf   m4                                                                                                         4.5s
 => [builder 3/5] COPY ./ /app                                                                                                                                                           0.1s 
 => [builder 4/5] WORKDIR /app                                                                                                                                                           0.0s 
 => [builder 5/5] RUN autoreconf --install && ./configure && make                                                                                                                        9.9s 
 => CACHED [stage-1 2/2] COPY --from=builder /app/src/fping /usr/local/bin/fping                                                                                                         0.0s 
 => exporting to image                                                                                                                                                                   0.0s 
 => => exporting layers                                                                                                                                                                  0.0s 
 => => writing image sha256:b5480dfcc4b5c61516a8732ea1cc4b8f4bf83f922adf7e317b55f9ef21af6d01                                                                                             0.0s
 => => naming to docker.io/library/fping  
```
```
# docker run --rm fping:latest 8.8.8.8

8.8.8.8 is alive
```
