### PR TITLE
Fix off-by-one boundary check in seqmap code

### DIFF
--- a/src/seqmap.c
+++ b/src/seqmap.c
@@ -106,7 +106,7 @@ SEQMAP_VALUE* seqmap_fetch(unsigned int id, int64_t now)
 {
     SEQMAP_VALUE* value;
 
-    if (id > SEQMAP_MAXSEQ) {
+    if (id >= SEQMAP_MAXSEQ) {
         return NULL;
     }
 


### PR DESCRIPTION
Credit to David.A for finding the issue.