### PR TITLE
Remove macos-specific test to verify that -I is not supported, since …

### DIFF
--- a/ci/test-07-options-i-m.pl
+++ b/ci/test-07-options-i-m.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 
-use Test::Command tests => 28;
+use Test::Command tests => 25;
 use Test::More;
 
 #  -i n       interval between sending ping packets (in millisec) (default 25)
@@ -52,17 +52,6 @@ my $cmd = Test::Command->new(cmd => 'fping -I NotAnInterface 127.0.0.1');
 $cmd->exit_is_num(1);
 $cmd->stdout_is_eq("");
 $cmd->stderr_like(qr{binding to specific interface \(SO_BINDTODEVICE\):.*\n});
-}
-
-# fping -I IFACE
-SKIP: {
-if($^O ne 'darwin') {
-    skip 'test for unsupported -I on macOS', 3;
-}
-my $cmd = Test::Command->new(cmd => 'fping -I lo0 127.0.0.1');
-$cmd->exit_is_num(3);
-$cmd->stdout_is_eq("fping: cant bind to a particular net interface since SO_BINDTODEVICE is not supported on your os.\n");
-$cmd->stderr_is_eq("");
 }
 
 # fping -l


### PR DESCRIPTION
…that seems to work now.

Failed test:

```
#   Failed test 'exit_is_num: fping -I lo0 127.0.0.1, 3'
#   at ci/test-07-options-i-m.pl line 63.
#          got: 0
#     expected: 3

#   Failed test 'stdout_is_eq: fping -I lo0 127.0.0.1, fping: cant bind to a particular net interface since SO_BINDTODEVICE is not supported on your os.
# '
#   at ci/test-07-options-i-m.pl line 64.
#          got: '127.0.0.1 is alive
# '
#     expected: 'fping: cant bind to a particular net interface since SO_BINDTODEVICE is not supported on your os.
# '
# Looks like you failed 2 tests of 28.
```