### PR TITLE
prevent allocation size computation overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ Next
   (#392, thanks @gsnw-sebast and @auerswal)
 - Switch to alpine-based multi-stage Docker build to reduce image size and improve build performance
   Add OpenContainers-compatible labels (#399)
+- Avoid unsigned overflow when determining the memory size to save
+  response times on systems where size\_t is the same as unsigned int
+  (#412 by @auerswal)
 
 fping 5.4 (UNRELEASED)
 ======================

--- a/src/fping.c
+++ b/src/fping.c
@@ -41,6 +41,7 @@ extern "C" {
 
 #include <errno.h>
 #include <inttypes.h>
+#include <limits.h>
 #include <signal.h>
 #include <stdarg.h>
 #include <stdint.h>
@@ -3439,6 +3440,10 @@ void add_addr(char *name, char *host, struct sockaddr *ipaddr, socklen_t ipaddr_
 
     /* array for response time results */
     if (!loop_flag) {
+#if SIZE_MAX <= UINT_MAX
+        if (trials > (SIZE_MAX / sizeof(int64_t)))
+            crash_and_burn("resp_times array too large for memory");
+#endif
         i = (int64_t *)malloc(trials * sizeof(int64_t));
         if (!i)
             crash_and_burn("can't allocate resp_times array");


### PR DESCRIPTION
On systems where size_t is unsigned int, computing the size of the resp_times array can overflow.  Add a check to prevent this.

On a 64-bit x86_64 Ubuntu 22.04.5 LTS system, the overflow check results in a compiler warning:

```
fping.c: In function ‘add_addr’:
fping.c:3444:20: warning: comparison is always false due to limited range of data type [-Wtype-limits]
 3444 |         if (trials > (SIZE_MAX / sizeof(int64_t)))
      |                    ^
```

Thus limit the check to systems with a size_t equal to (or less than) unsigned int.