### PR TITLE
initialize all resp_times array entries

### DIFF
--- a/src/fping.c
+++ b/src/fping.c
@@ -3548,7 +3548,7 @@ void add_addr(char *name, char *host, struct sockaddr *ipaddr, socklen_t ipaddr_
         if (!i)
             crash_and_burn("can't allocate resp_times array");
 
-        for (n = 1; n < trials; n++)
+        for (n = 0; n < trials; n++)
             i[n] = RESP_UNUSED;
 
         p->resp_times = i;


### PR DESCRIPTION
Before, the resp_times array was initialized starting with the second entry, leaving the first entry uninitialized.  This is at least confusing.  Initializing one additional int64_t value per ping target should not add too much overhead, so do this just to be on the safe side.

Assuming that the first array entry need not be initialized when creating the array now, this guards against potential problems from future code changes that do not take this unexpected special case into account.