### PR TITLE
ci: Github action Build and Push Docker Image

### DIFF
--- a/.github/workflows/docker-deployment.yml
+++ b/.github/workflows/docker-deployment.yml
@@ -1,0 +1,65 @@
+name: Build and Push Docker Image
+on:
+  workflow_run:
+    workflows: ["Test"]
+    types:
+      - completed
+permissions:
+  contents: read
+  packages: write
+  id-token: write    # Cosign OIDC-Signing
+  actions: write     # Upload Artifacts
+  attestations: write # build-provenance
+env:
+  REGISTRY: ghcr.io
+jobs:
+  push_to_regsitry:
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push'
+    name: Push Docker image to Github Container Redistry
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Login Github Container Redistry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository }}
+          tags: |
+            type=raw,value=latest
+
+      - name: Build and push Docker image
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          file: contrib/Dockerfile
+          context: .
+          push: true
+          provenance: false
+          sbom: false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          target: ""
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign image with Cosign
+        run: cosign sign --yes ${{ env.REGISTRY }}/${{ github.repository }}@${{ steps.build.outputs.digest }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ github.repository }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true


### PR DESCRIPTION
I created a GitHub Action job that stores a Docker image in the GitHub Container Registry from the current develop branch every time there is a push and the GitHub Action `Test` runs successfully.

This can then be used via `docker pull ghcr.io/schweikert/fping:latest`.

An example can be found at https://github.com/gsnw/fping/pkgs/container/fping and the build process at https://github.com/gsnw/fping/actions/runs/17546783325
Unfortunately, I was unable to test the dependent start in Github Action in advance.

To use it, the fping package must be set to public after it has been automatically created for the first time.

What do you think about that?