### PR TITLE
ci: Start the GitHub action Build and Push Docker Image only when pushing to develop branch

### DIFF
--- a/.github/workflows/docker-deployment.yml
+++ b/.github/workflows/docker-deployment.yml
@@ -13,7 +13,7 @@ permissions:
 env:
   REGISTRY: ghcr.io
 jobs:
-  push_to_regsitry:
+  push_to_registry:
     if: >
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'push' &&

--- a/.github/workflows/docker-deployment.yml
+++ b/.github/workflows/docker-deployment.yml
@@ -16,7 +16,8 @@ jobs:
   push_to_regsitry:
     if: >
       github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'push'
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'develop'
     name: Push Docker image to Github Container Redistry
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
When a new branch is created and a push is made to it, the GitHub action `Build and Push Docker Image` is also started.
This change means that a Docker image is only built and published when a push is made to the develop branch.