### PR TITLE
json: simplify recv and timeout output (and code)

### DIFF
--- a/ci/test-16-json-output.pl
+++ b/ci/test-16-json-output.pl
@@ -7,8 +7,8 @@ use Test::More;
 {
 my $cmd = Test::Command->new(cmd => "fping -J -c 2 127.0.0.1");
 $cmd->exit_is_num(0);
-$cmd->stdout_like(qr/^\{"resp":\s\{"host":\s"127\.0\.0\.1",\s"seq":\s0,\s"size":\s\d+,\s"rtt":\s\d+\.\d+,\s"rttAvg":\s\d+\.\d+,\s"loss":\s\d+\}\}
-\{"resp":\s\{"host":\s"127\.0\.0\.1",\s"seq":\s1,\s"size":\s\d+,\s"rtt":\s\d+\.\d+,\s"rttAvg":\s\d+\.\d+,\s"loss":\s\d+\}\}
+$cmd->stdout_like(qr/^\{"resp":\s\{"host":\s"127\.0\.0\.1",\s"seq":\s0,\s"size":\s\d+,\s"rtt":\s\d+\.\d+\}\}
+\{"resp":\s\{"host":\s"127\.0\.0\.1",\s"seq":\s1,\s"size":\s\d+,\s"rtt":\s\d+\.\d+\}\}
 \{"summary":\s\{"host":\s"127\.0\.0\.1",\s"xmt":\s\d+,\s"rcv":\s\d+,\s"loss":\s\d+,\s"rttMin":\s\d+\.\d+,\s"rttAvg":\s\d+\.\d+,\s"rttMax":\s\d+\.\d+\}\}\n?$/);
 $cmd->stderr_is_eq("");
 }
@@ -20,7 +20,7 @@ if($^O eq 'darwin') {
 }
 my $cmd = Test::Command->new(cmd => "fping -J -c 1 --icmp-timestamp 127.0.0.1");
 $cmd->exit_is_num(0);
-$cmd->stdout_like(qr/^\{"resp":\s\{"host":\s"127\.0\.0\.1",\s"seq":\s0,\s"size":\s\d+,\s"rtt":\s\d+\.\d+,\s"rttAvg":\s\d+\.\d+,\s"loss":\s\d+,\s"timestamps":\s\{"originate":\s\d+,\s"receive":\s\d+,\s"transmit":\s\d+,\s"localreceive":\s\d+\}\}\}
+$cmd->stdout_like(qr/^\{"resp":\s\{"host":\s"127\.0\.0\.1",\s"seq":\s0,\s"size":\s\d+,\s"rtt":\s\d+\.\d+,\s"timestamps":\s\{"originate":\s\d+,\s"receive":\s\d+,\s"transmit":\s\d+,\s"localreceive":\s\d+\}\}\}
 \{"summary":\s\{"host":\s"127\.0\.0\.1",\s"xmt":\s\d+,\s"rcv":\s\d+,\s"loss":\s\d+,\s"rttMin":\s\d+\.\d+,\s"rttAvg":\s\d+\.\d+,\s"rttMax":\s\d+\.\d+\}\}\n?$/);
 $cmd->stderr_is_eq("");
 }
@@ -29,7 +29,7 @@ $cmd->stderr_is_eq("");
 {
 my $cmd = Test::Command->new(cmd => "fping -J -c 1 --print-ttl 127.0.0.1");
 $cmd->exit_is_num(0);
-$cmd->stdout_like(qr/^\{"resp":\s\{"host":\s"127\.0\.0\.1",\s"seq":\s0,\s"size":\s\d+,\s"rtt":\s\d+\.\d+,\s"rttAvg":\s\d+\.\d+,\s"loss":\s\d+,\s"ttl":\s\d+\}\}
+$cmd->stdout_like(qr/^\{"resp":\s\{"host":\s"127\.0\.0\.1",\s"seq":\s0,\s"size":\s\d+,\s"rtt":\s\d+\.\d+,\s"ttl":\s\d+\}\}
 \{"summary":\s\{"host":\s"127\.0\.0\.1",\s"xmt":\s\d+,\s"rcv":\s\d+,\s"loss":\s\d+,\s"rttMin":\s\d+\.\d+,\s"rttAvg":\s\d+\.\d+,\s"rttMax":\s\d+\.\d+\}\}\n?$/);
 $cmd->stderr_is_eq("");
 }
@@ -38,7 +38,7 @@ $cmd->stderr_is_eq("");
 {
 my $cmd = Test::Command->new(cmd => "fping -J -c 1 --print-tos 127.0.0.1");
 $cmd->exit_is_num(0);
-$cmd->stdout_like(qr/^\{"resp":\s\{"host":\s"127\.0\.0\.1",\s"seq":\s0,\s"size":\s\d+,\s"rtt":\s\d+\.\d+,\s"rttAvg":\s\d+\.\d+,\s"loss":\s\d+,\s"tos":\s\d+\}\}
+$cmd->stdout_like(qr/^\{"resp":\s\{"host":\s"127\.0\.0\.1",\s"seq":\s0,\s"size":\s\d+,\s"rtt":\s\d+\.\d+,\s"tos":\s\d+\}\}
 \{"summary":\s\{"host":\s"127\.0\.0\.1",\s"xmt":\s\d+,\s"rcv":\s\d+,\s"loss":\s\d+,\s"rttMin":\s\d+\.\d+,\s"rttAvg":\s\d+\.\d+,\s"rttMax":\s\d+\.\d+\}\}\n?$/);
 $cmd->stderr_is_eq("");
 }
@@ -47,7 +47,7 @@ $cmd->stderr_is_eq("");
 {
 my $cmd = Test::Command->new(cmd => "fping -J -c 1 --print-ttl --print-tos 127.0.0.1");
 $cmd->exit_is_num(0);
-$cmd->stdout_like(qr/^\{"resp":\s\{"host":\s"127\.0\.0\.1",\s"seq":\s0,\s"size":\s\d+,\s"rtt":\s\d+\.\d+,\s"rttAvg":\s\d+\.\d+,\s"loss":\s\d+,\s"tos":\s\d+,\s"ttl":\s\d+\}\}
+$cmd->stdout_like(qr/^\{"resp":\s\{"host":\s"127\.0\.0\.1",\s"seq":\s0,\s"size":\s\d+,\s"rtt":\s\d+\.\d+,\s"tos":\s\d+,\s"ttl":\s\d+\}\}
 \{"summary":\s\{"host":\s"127\.0\.0\.1",\s"xmt":\s\d+,\s"rcv":\s\d+,\s"loss":\s\d+,\s"rttMin":\s\d+\.\d+,\s"rttAvg":\s\d+\.\d+,\s"rttMax":\s\d+\.\d+\}\}\n?$/);
 $cmd->stderr_is_eq("");
 }
@@ -56,7 +56,7 @@ $cmd->stderr_is_eq("");
 {
 my $cmd = Test::Command->new(cmd => "fping -J -c 1 192.0.2.47");
 $cmd->exit_is_num(1);
-$cmd->stdout_like(qr/^\{"timeout":\s\{"host":\s"192\.0\.2\.47",\s"seq":\s\d+,\s"rttAvg":\s"NaN",\s"loss":\s\d+\}\}
+$cmd->stdout_like(qr/^\{"timeout":\s\{"host":\s"192\.0\.2\.47",\s"seq":\s\d+\}\}
 \{"summary":\s\{"host":\s"192\.0\.2\.47",\s"xmt":\s\d+,\s"rcv":\s\d+,\s"loss":\s\d+\}\}\n?$/);
 $cmd->stderr_is_eq("");
 }
@@ -65,8 +65,8 @@ $cmd->stderr_is_eq("");
 {
 my $cmd = Test::Command->new(cmd => "fping -J -c 2 -D 127.0.0.1");
 $cmd->exit_is_num(0);
-$cmd->stdout_like(qr/^\{"resp":\s\{"timestamp":\s"\d+.\d+",\s"host":\s"127\.0\.0\.1",\s"seq":\s0,\s"size":\s\d+,\s"rtt":\s\d+\.\d+,\s"rttAvg":\s\d+\.\d+,\s"loss":\s\d+\}\}
-\{"resp":\s\{"timestamp":\s"\d+.\d+",\s"host":\s"127\.0\.0\.1",\s"seq":\s1,\s"size":\s\d+,\s"rtt":\s\d+\.\d+,\s"rttAvg":\s\d+\.\d+,\s"loss":\s\d+\}\}
+$cmd->stdout_like(qr/^\{"resp":\s\{"timestamp":\s"\d+.\d+",\s"host":\s"127\.0\.0\.1",\s"seq":\s0,\s"size":\s\d+,\s"rtt":\s\d+\.\d+\}\}
+\{"resp":\s\{"timestamp":\s"\d+.\d+",\s"host":\s"127\.0\.0\.1",\s"seq":\s1,\s"size":\s\d+,\s"rtt":\s\d+\.\d+\}\}
 \{"summary":\s\{"host":\s"127\.0\.0\.1",\s"xmt":\s\d+,\s"rcv":\s\d+,\s"loss":\s\d+,\s"rttMin":\s\d+\.\d+,\s"rttAvg":\s\d+\.\d+,\s"rttMax":\s\d+\.\d+\}\}\n?$/);
 $cmd->stderr_is_eq("");
 }
@@ -75,7 +75,7 @@ $cmd->stderr_is_eq("");
 {
 my $cmd = Test::Command->new(cmd => "fping -J -c 1 -D --timestamp-format=ctime 127.0.0.1");
 $cmd->exit_is_num(0);
-$cmd->stdout_like(qr/^\{"resp":\s\{"timestamp":\s"\w+\s\w+\s+\d+\s[\d+:]+\s\d+",\s"host":\s"127\.0\.0\.1",\s"seq":\s0,\s"size":\s\d+,\s"rtt":\s\d+\.\d+,\s"rttAvg":\s\d+\.\d+,\s"loss":\s\d+\}\}
+$cmd->stdout_like(qr/^\{"resp":\s\{"timestamp":\s"\w+\s\w+\s+\d+\s[\d+:]+\s\d+",\s"host":\s"127\.0\.0\.1",\s"seq":\s0,\s"size":\s\d+,\s"rtt":\s\d+\.\d+\}\}
 \{"summary":\s\{"host":\s"127\.0\.0\.1",\s"xmt":\s\d+,\s"rcv":\s\d+,\s"loss":\s\d+,\s"rttMin":\s\d+\.\d+,\s"rttAvg":\s\d+\.\d+,\s"rttMax":\s\d+\.\d+\}\}\n?$/);
 $cmd->stderr_is_eq("");
 }
@@ -84,7 +84,7 @@ $cmd->stderr_is_eq("");
 {
 my $cmd = Test::Command->new(cmd => "fping -J -c 1 -D --timestamp-format=iso 127.0.0.1");
 $cmd->exit_is_num(0);
-$cmd->stdout_like(qr/^\{"resp":\s\{"timestamp":\s"[\d+-]+T[\d+:]+\+\d+",\s"host":\s"127\.0\.0\.1",\s"seq":\s0,\s"size":\s\d+,\s"rtt":\s\d+\.\d+,\s"rttAvg":\s\d+\.\d+,\s"loss":\s\d+\}\}
+$cmd->stdout_like(qr/^\{"resp":\s\{"timestamp":\s"[\d+-]+T[\d+:]+\+\d+",\s"host":\s"127\.0\.0\.1",\s"seq":\s0,\s"size":\s\d+,\s"rtt":\s\d+\.\d+\}\}
 \{"summary":\s\{"host":\s"127\.0\.0\.1",\s"xmt":\s\d+,\s"rcv":\s\d+,\s"loss":\s\d+,\s"rttMin":\s\d+\.\d+,\s"rttAvg":\s\d+\.\d+,\s"rttMax":\s\d+\.\d+\}\}\n?$/);
 $cmd->stderr_is_eq("");
 }
@@ -93,7 +93,7 @@ $cmd->stderr_is_eq("");
 {
 my $cmd = Test::Command->new(cmd => "fping -J -c 1 -D --timestamp-format=rfc3339 127.0.0.1");
 $cmd->exit_is_num(0);
-$cmd->stdout_like(qr/^\{"resp":\s\{"timestamp":\s"[\d+-]+\s[\d+:]+",\s"host":\s"127\.0\.0\.1",\s"seq":\s0,\s"size":\s\d+,\s"rtt":\s\d+\.\d+,\s"rttAvg":\s\d+\.\d+,\s"loss":\s\d+\}\}
+$cmd->stdout_like(qr/^\{"resp":\s\{"timestamp":\s"[\d+-]+\s[\d+:]+",\s"host":\s"127\.0\.0\.1",\s"seq":\s0,\s"size":\s\d+,\s"rtt":\s\d+\.\d+\}\}
 \{"summary":\s\{"host":\s"127\.0\.0\.1",\s"xmt":\s\d+,\s"rcv":\s\d+,\s"loss":\s\d+,\s"rttMin":\s\d+\.\d+,\s"rttAvg":\s\d+\.\d+,\s"rttMax":\s\d+\.\d+\}\}\n?$/);
 $cmd->stderr_is_eq("");
 }
@@ -110,7 +110,7 @@ $cmd->stderr_is_eq("");
 {
 my $cmd = Test::Command->new(cmd => "fping -J -C 1 127.0.0.1");
 $cmd->exit_is_num(0);
-$cmd->stdout_like(qr/^\{"resp":\s\{"host":\s"127\.0\.0\.1",\s"seq":\s\d+,\s"size":\s\d+,\s"rtt":\s\d+.\d+,\s"rttAvg":\s\d+.\d+,\s"loss":\s\d+\}\}
+$cmd->stdout_like(qr/^\{"resp":\s\{"host":\s"127\.0\.0\.1",\s"seq":\s\d+,\s"size":\s\d+,\s"rtt":\s\d+.\d+\}\}
 \{"vSum":\s\{"host":\s"127\.0\.0\.1",\s"values":\s\[\d+.\d+\]\}\}?$/);
 $cmd->stderr_is_eq("");
 }
@@ -119,7 +119,7 @@ $cmd->stderr_is_eq("");
 {
 my $cmd = Test::Command->new(cmd => "fping -J -C 1 192.0.2.47");
 $cmd->exit_is_num(1);
-$cmd->stdout_like(qr/^\{"timeout":\s\{"host":\s"192\.0\.2\.47",\s"seq":\s\d+,\s"rttAvg":\s"NaN",\s"loss":\s\d+\}\}
+$cmd->stdout_like(qr/^\{"timeout":\s\{"host":\s"192\.0\.2\.47",\s"seq":\s\d+\}\}
 \{"vSum":\s\{"host":\s"192\.0\.2\.47",\s"values":\s\[null\]\}\}?$/);
 $cmd->stderr_is_eq("");
 }

--- a/src/fping.c
+++ b/src/fping.c
@@ -449,7 +449,7 @@ int send_ping(HOST_ENTRY *h, int index);
 void usage(int);
 int wait_for_reply(int64_t);
 void print_recv(HOST_ENTRY *h, int64_t recv_time, int result, int this_count, int64_t this_reply, int avg);
-void print_recv_json(HOST_ENTRY *h, int64_t recv_time, int result, int this_count, int64_t this_reply, int avg);
+void print_timeout(HOST_ENTRY *h, int ping_index);
 void print_recv_ext(IP_HEADER_RESULT *ip_header_res, int64_t recv_time, int64_t this_reply);
 void print_recv_ext_json(IP_HEADER_RESULT *ip_header_res, int64_t recv_time, int64_t this_reply);
 void print_per_system_stats(void);
@@ -1773,56 +1773,7 @@ void main_loop()
             stats_add(h, event->ping_index, 0, -1);
 
             if (per_recv_flag) {
-                if (json_flag)
-                    printf("{\"timeout\": {");
-
-                if (timestamp_flag)
-                    print_timestamp_format(current_time_ns, timestamp_format_flag);
-
-                if (json_flag)
-                {
-                  printf("\"host\": \"%s\", ", h->host);
-                  printf("\"seq\": %d", event->ping_index);
-                }
-                else {
-                    printf("%-*s : [%d], timed out",
-                        max_hostname_len, h->host, event->ping_index);
-                }
-                if (h->num_recv > 0) {
-                    if (json_flag)
-                        printf(", \"rttAvg\": %s", sprint_tm(h->total_time / h->num_recv));
-                    else
-                        printf(" (%s avg, ", sprint_tm(h->total_time / h->num_recv));
-                }
-                else {
-                    if (json_flag)
-                        printf(", \"rttAvg\": \"NaN\"");
-                    else
-                        printf(" (NaN avg, ");
-                }
-                if (h->num_recv <= h->num_sent) {
-                    if (json_flag) {
-                        printf(", \"loss\": %d", ((h->num_sent - h->num_recv) * 100) / h->num_sent);
-                    }
-                    else {
-                        printf("%d%% loss)",
-                            ((h->num_sent - h->num_recv) * 100) / h->num_sent);
-                    }
-                }
-                else {
-                    if (json_flag) {
-                        printf(", \"return\": %d", (h->num_recv_total * 100) / h->num_sent);
-                    }
-                    else {
-                        printf("%d%% return)",
-                            (h->num_recv_total * 100) / h->num_sent);
-                    }
-                }
-
-                if (json_flag)
-                    printf("}}");
-                
-                printf("\n");
+                print_timeout(h, event->ping_index);
             }
 
             /* do we need to send a retry? */
@@ -2092,12 +2043,26 @@ void finish()
 ************************************************************/
 
 void print_recv(HOST_ENTRY *h, int64_t recv_time, int result, int this_count, int64_t this_reply, int avg) {
+    if (json_flag) {
+        printf("{\"resp\": {");
+
+        if (timestamp_flag)
+            print_timestamp_format(recv_time, timestamp_format_flag);
+
+        printf("\"host\": \"%s\", ", h->host);
+        printf("\"seq\": %d, ", this_count);
+        printf("\"size\": %d, ", result);
+        printf("\"rtt\": %s", sprint_tm(this_reply));
+        return;
+    }
+
+    /* Normal Output */
     if (timestamp_flag)
         print_timestamp_format(recv_time, timestamp_format_flag);
 
     printf("%-*s : [%d], %d bytes, %s ms",
         max_hostname_len, h->host, this_count, result, sprint_tm(this_reply));
-    
+
     printf(" (%s avg, ", sprint_tm(avg));
 
     if (h->num_recv <= h->num_sent) {
@@ -2112,35 +2077,51 @@ void print_recv(HOST_ENTRY *h, int64_t recv_time, int result, int this_count, in
 
 /************************************************************
 
-  Function: print_recv_json
+  Function: print_timeout
 
 *************************************************************
 
-  Inputs: HOST_ENTRY *h, int64_t recv_time, int result,
-          int this_count, int64_t this_reply, int avg
+  Inputs: HOST_ENTRY *h, int ping_index
 
   Description:
 
 ************************************************************/
 
-void print_recv_json(HOST_ENTRY *h, int64_t recv_time, int result, int this_count, int64_t this_reply, int avg) {
-    printf("{\"resp\": {");
+void print_timeout(HOST_ENTRY *h, int ping_index) {
+    if (json_flag) {
+        printf("{\"timeout\": {");
+        if (timestamp_flag)
+            print_timestamp_format(current_time_ns, timestamp_format_flag);
 
+        printf("\"host\": \"%s\", ", h->host);
+        printf("\"seq\": %d", ping_index);
+        printf("}}\n");
+        return;
+    }
+
+    /* Normal Output */
     if (timestamp_flag)
-        print_timestamp_format(recv_time, timestamp_format_flag);
-    
-    printf("\"host\": \"%s\", ", h->host);
-    printf("\"seq\": %d, ", this_count);
-    printf("\"size\": %d, ", result);
-    printf("\"rtt\": %s, ", sprint_tm(this_reply));
-    printf("\"rttAvg\": %s", sprint_tm(avg));
+        print_timestamp_format(current_time_ns, timestamp_format_flag);
 
-    if (h->num_recv <= h->num_sent) {
-        printf(", \"loss\": %d", ((h->num_sent - h->num_recv) * 100) / h->num_sent);
+    printf("%-*s : [%d], timed out",
+        max_hostname_len, h->host, ping_index);
+
+    if (h->num_recv > 0) {
+        printf(" (%s avg, ", sprint_tm(h->total_time / h->num_recv));
     }
     else {
-        printf(", \"return\": %d", (h->num_recv_total * 100) / h->num_sent);
+        printf(" (NaN avg, ");
     }
+
+    if (h->num_recv <= h->num_sent) {
+        printf("%d%% loss)",
+            ((h->num_sent - h->num_recv) * 100) / h->num_sent);
+    }
+    else {
+        printf("%d%% return)",
+            (h->num_recv_total * 100) / h->num_sent);
+    }
+    printf("\n");
 }
 
 /************************************************************
@@ -3340,22 +3321,12 @@ int wait_for_reply(int64_t wait_time)
     /* print received ping (unless --quiet) */
     if (per_recv_flag) {
         avg = h->total_time / h->num_recv;
-        if (json_flag) {
-            print_recv_json(h,
-                recv_time,
-                result,
-                this_count,
-                this_reply,
-                avg);
-        }
-        else {
-            print_recv(h,
-                recv_time,
-                result,
-                this_count,
-                this_reply,
-                avg);
-        }
+        print_recv(h,
+            recv_time,
+            result,
+            this_count,
+            this_reply,
+            avg);
     }
 
     if (verbose_flag || alive_flag || per_recv_flag) {


### PR DESCRIPTION
The rttAvg, loss, and return fields are not really useful IMO, at least not in the JSON output, which is mainly targeting machine-processing of the output (and calculating averages / percentages as you see fit, is easy enough).