### PR TITLE
ci: Fix test unkown host

### DIFF
--- a/ci/test-13-unknown-host.pl
+++ b/ci/test-13-unknown-host.pl
@@ -7,5 +7,5 @@ use Test::Command tests => 3;
 my $cmd = Test::Command->new(cmd => "fping nosuchname.example.com");
 $cmd->exit_is_num(2);
 $cmd->stdout_is_eq("");
-$cmd->stderr_like(qr{^nosuchname\.example\.com: .*not (known|found)});
+$cmd->stderr_like(qr{^nosuchname\.example\.com: (.*not (known|found)|No address associated with hostname)});
 }


### PR DESCRIPTION
Extension of the test unknown host so that a response `No address associated with hostname` is also processed.