### PR TITLE
ci: Github action Build and Push Docker Image rollback sigstore osign-installer version

### DIFF
--- a/.github/workflows/docker-deployment.yml
+++ b/.github/workflows/docker-deployment.yml
@@ -53,7 +53,7 @@ jobs:
           target: ""
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v4
+        uses: sigstore/cosign-installer@v3
 
       - name: Sign image with Cosign
         run: cosign sign --yes ${{ env.REGISTRY }}/${{ github.repository }}@${{ steps.build.outputs.digest }}


### PR DESCRIPTION
As a workaround, I reverted back Github action `sigstore/osign-installer` to version 3.

Issue: #428 