### PR TITLE
Fix usage pod2man under FreeBSD and OpenBSD

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -3,4 +3,4 @@ man_MANS = fping.8
 EXTRA_DIST = fping.8 fping.pod README.1992 CHANGELOG.pre-v4
 
 fping.8: fping.pod
-	pod2man  -c "" -s 8 -r "fping" $< >$@
+	pod2man  -c "" -s 8 -r "fping" fping.pod > fping.8


### PR DESCRIPTION
When building fping on FreeBSD and OpenBSD, the process hangs at doc/Makefile.in. With this change, the whole thing works even without gmake or the OpenBSD patch.

OpenBSD patch: https://cvsweb.openbsd.org/ports/net/fping/patches/patch-doc_Makefile_in