### PR TITLE
New option --traceroute to send a traceroute with fping

### DIFF
--- a/doc/fping.pod
+++ b/doc/fping.pod
@@ -169,6 +169,14 @@ the local receive time in the same format, in addition to normal output.
 Cannot be used together with B<-b> because ICMP timestamp messages have a fixed size.
 IPv4 only, requires root privileges or cap_net_raw.
 
+=item B<--traceroute>
+
+Sends a traceroute based on ICMP echo request. Root privileges are required.
+
+Example usage:
+
+$: fping --traceroute 127.0.0.1
+
 =item B<-J>, B<--json>
 
 Format output JSON (-c, -C, or -l required)

--- a/src/flags.c
+++ b/src/flags.c
@@ -25,6 +25,7 @@ int opt_quiet_on = 0;
 int opt_elapsed_on = 0;
 int opt_stats_on = 0;
 int opt_cumulative_stats_on = 0;
+int opt_traceroute_on = 0;
 int opt_generate_on = 0; /* flag for IP list generation */
 int opt_count_on = 0;
 int opt_loop_on = 0;

--- a/src/flags.h
+++ b/src/flags.h
@@ -29,6 +29,7 @@ extern int opt_quiet_on;
 extern int opt_elapsed_on;
 extern int opt_stats_on;
 extern int opt_cumulative_stats_on;
+extern int opt_traceroute_on;
 extern int opt_generate_on;
 extern int opt_count_on;
 extern int opt_loop_on;

--- a/src/fping.c
+++ b/src/fping.c
@@ -168,6 +168,10 @@ extern int h_errno;
 #define RESP_ERROR -3
 #define RESP_TIMEOUT -4
 
+/* Traceroute */
+#define TRACEROUTE_DEFAULT_MAX_TTL 30
+#define TRACEROUTE_DONE_TTL 100
+
 /* debugging flags */
 #if defined(DEBUG) || defined(_DEBUG)
 #define DBG_TRACE 1
@@ -498,6 +502,7 @@ int main(int argc, char **argv)
         { "rdns", 'd', OPTPARSE_NONE },
         { "timestamp", 'D', OPTPARSE_NONE },
         { "timestamp-format", 0, OPTPARSE_REQUIRED },
+        { "traceroute", 0, OPTPARSE_NONE },
         { "elapsed", 'e', OPTPARSE_NONE },
         { "file", 'f', OPTPARSE_REQUIRED },
         { "generate", 'g', OPTPARSE_NONE },
@@ -555,6 +560,8 @@ int main(int argc, char **argv)
                 }else{
                   usage(1);
                 }
+            } else if (strcmp(optparse_state.optlongname, "traceroute") == 0) {
+                opt_traceroute_on = 1;
             } else if (strstr(optparse_state.optlongname, "check-source") != NULL) {
                 opt_check_source_on = 1;
             } else if (strstr(optparse_state.optlongname, "icmp-timestamp") != NULL) {
@@ -1283,6 +1290,16 @@ int main(int argc, char **argv)
         exit(num_noaddress ? 2 : 1);
     }
 
+    /* 
+    if(opt_traceroute_on) {
+      // Preventing race conditions: Only one host allowed
+      if (num_hosts > 1) {
+          fprintf(stderr, "%s: traceroute mode only supports one target at a time\n", prog);
+          exit(1);
+      }
+    }
+    */
+
     if (socket4 >= 0 && (src_addr_set || socktype4 == SOCK_DGRAM)) {
         socket_set_src_addr_ipv4(socket4, &src_addr, (socktype4 == SOCK_DGRAM) ? &ident4 : NULL);
     }
@@ -1705,6 +1722,28 @@ void main_loop()
 
             dbg_printf("%s [%d]: ping event\n", h->host, event->ping_index);
 
+            /* Traceroute */
+            if (opt_traceroute_on) {
+                if (h->trace_ttl == TRACEROUTE_DONE_TTL) {
+                    continue;
+                }
+
+                int ttl_set = h->trace_ttl;
+                if (ttl_set > (int)opt_ttl) ttl_set = (int)opt_ttl;
+                if (socket4 >= 0) {
+                    if (setsockopt(socket4, IPPROTO_IP, IP_TTL, &ttl_set, sizeof(ttl_set)))
+                        perror("setsockopt IP_TTL");
+                }
+#ifdef IPV6
+                if (socket6 >= 0) {
+                    /* Set hop limit for IPv6 */
+                    if (setsockopt(socket6, IPPROTO_IPV6, IPV6_UNICAST_HOPS, &ttl_set, sizeof(ttl_set))) {
+                        perror("setsockopt IPV6_UNICAST_HOPS");
+                    }
+                }
+#endif
+            }
+
             /* Send the ping */
             send_ping(h, event->ping_index);
 
@@ -1953,6 +1992,14 @@ int send_ping(HOST_ENTRY *h, int index)
     int ret = 1;
     uint8_t proto = ICMP_ECHO;
 
+    // TTL
+    int send_ttl = 0;
+    if (opt_traceroute_on) {
+        send_ttl = h->trace_ttl;
+    } else if (opt_ttl > 0) {
+        send_ttl = opt_ttl;
+    }
+
     update_current_time();
     h->last_send_time = current_time_ns;
     myseq = seqmap_add(h->i, index, current_time_ns);
@@ -1962,11 +2009,11 @@ int send_ping(HOST_ENTRY *h, int index)
     if (h->saddr.ss_family == AF_INET && socket4 >= 0) {
         if(opt_icmp_request_typ == 13)
             proto = ICMP_TSTAMP;
-        n = socket_sendto_ping_ipv4(socket4, (struct sockaddr *)&h->saddr, h->saddr_len, myseq, ident4, proto);
+        n = socket_sendto_ping_ipv4(socket4, (struct sockaddr *)&h->saddr, h->saddr_len, myseq, ident4, proto, send_ttl);
     }
 #ifdef IPV6
     else if (h->saddr.ss_family == AF_INET6 && socket6 >= 0) {
-        n = socket_sendto_ping_ipv6(socket6, (struct sockaddr *)&h->saddr, h->saddr_len, myseq, ident6);
+        n = socket_sendto_ping_ipv6(socket6, (struct sockaddr *)&h->saddr, h->saddr_len, myseq, ident6, send_ttl);
     }
 #endif
     else {
@@ -2380,6 +2427,27 @@ int decode_icmp_ipv6(
 
     icp = (struct icmp6_hdr *)reply_buf;
 
+    /* Traceroute Logic for IPv6 Time Exceeded */
+    if (opt_traceroute_on && icp->icmp6_type == ICMP6_TIME_EXCEEDED) {
+        struct ip6_hdr *inner_ip6;
+        struct icmp6_hdr *inner_icmp6;
+
+        if (reply_buf_len >= sizeof(struct icmp6_hdr) + sizeof(struct ip6_hdr) + sizeof(struct icmp6_hdr)) {
+            inner_ip6 = (struct ip6_hdr *)(reply_buf + sizeof(struct icmp6_hdr));
+
+            /* Check whether the inner packet is ICMPv6 */
+            if (inner_ip6->ip6_nxt == IPPROTO_ICMPV6) {
+                inner_icmp6 = (struct icmp6_hdr *)(reply_buf + sizeof(struct icmp6_hdr) + sizeof(struct ip6_hdr));
+
+                if (inner_icmp6->icmp6_id == ident6) {
+                    *id = inner_icmp6->icmp6_id;
+                    *seq = ntohs(inner_icmp6->icmp6_seq);
+                    return 1;
+                }
+            }
+        }
+    }
+
     if (icp->icmp6_type != ICMP6_ECHO_REPLY) {
         /* Handle other ICMPv6 packets */
         struct ip6_hdr *sent_ipv6;
@@ -2484,6 +2552,7 @@ int wait_for_reply(int64_t wait_time)
     static char buffer[RECV_BUFSIZE];
     struct sockaddr_storage response_addr;
     int n, avg;
+    int ip_hlen = 0;
     HOST_ENTRY *h;
     int64_t this_reply;
     int this_count;
@@ -2514,7 +2583,7 @@ int wait_for_reply(int64_t wait_time)
 
     /* Process ICMP packet and retrieve id/seq */
     if (response_addr.ss_family == AF_INET) {
-        int ip_hlen = decode_icmp_ipv4(
+        ip_hlen = decode_icmp_ipv4(
             (struct sockaddr *)&response_addr,
             sizeof(response_addr),
             buffer,
@@ -2599,6 +2668,35 @@ int wait_for_reply(int64_t wait_time)
         return 1;
     }
 
+    if (opt_traceroute_on && response_addr.ss_family == AF_INET) {
+        struct icmp *icp = (struct icmp *)(buffer + ip_hlen);
+        char ip_str[INET_ADDRSTRLEN];
+        getnameinfo((struct sockaddr *)&response_addr, sizeof(response_addr), ip_str, sizeof(ip_str), NULL, 0, NI_NUMERICHOST);
+
+        if (icp->icmp_type == ICMP_TIMXCEED) {
+            handle_traceroute_hop(h, ip_str, 0, this_reply);
+        } else { /* ICMP_ECHOREPLY */
+            handle_traceroute_hop(h, ip_str, 1, this_reply);
+        }
+    }
+#ifdef IPV6
+    else if (opt_traceroute_on && response_addr.ss_family == AF_INET6) {
+        struct icmp6_hdr *icp = (struct icmp6_hdr *)buffer;
+
+        if (icp->icmp6_type == ICMP6_TIME_EXCEEDED || icp->icmp6_type == ICMP6_ECHO_REPLY) {
+            /* With IPv6, buffer is directly the ICMP header payload, since receive_packet uses recvmsg */
+            char ip_str[INET6_ADDRSTRLEN];
+            getnameinfo((struct sockaddr *)&response_addr, sizeof(response_addr), ip_str, sizeof(ip_str), NULL, 0, NI_NUMERICHOST);
+
+            if (icp->icmp6_type == ICMP6_TIME_EXCEEDED) {
+                handle_traceroute_hop(h, ip_str, 0, this_reply);
+            } else { /* ICMP6_ECHO_REPLY */
+                handle_traceroute_hop(h, ip_str, 1, this_reply);
+            }
+        }
+    }
+#endif
+
     /* update stats */
     stats_add(h, this_count, 1, this_reply);
     // TODO: move to stats_add?
@@ -2616,6 +2714,10 @@ int wait_for_reply(int64_t wait_time)
     struct event *timeout_event = host_get_timeout_event(h, this_count);
     if (timeout_event) {
         ev_remove(&event_queue_timeout, timeout_event);
+    }
+
+    if (opt_traceroute_on) {
+      return 1;
     }
 
     /* print "is alive" */
@@ -2810,6 +2912,7 @@ void add_addr(char *name, char *host, struct sockaddr *ipaddr, socklen_t ipaddr_
     p->saddr_len = ipaddr_len;
     p->timeout = opt_timeout;
     p->min_reply = 0;
+    p->trace_ttl = 1;
 
     if (opt_print_netdata_on) {
         char *s = p->name;
@@ -3062,7 +3165,39 @@ void ev_remove(struct event_queue *queue, struct event *event)
     event->ev_next = NULL;
 }
 
+/************************************************************
 
+  Function: handle_traceroute_hop
+
+*************************************************************
+
+  Input:
+    h:                    host entry
+    ip_str:               textual IP of reply source
+    reached_destination:  non-zero if destination was reached
+    this_reply:           reply latency in ns
+
+  Desciption:
+
+  A small helper to centralize printing and TTL handling for
+  traceroute replies (both IPv4 and IPv6). This reduces code
+  duplication and keeps behaviour consistent.
+
+*************************************************************/
+
+void handle_traceroute_hop(HOST_ENTRY *h, const char *ip_str, int reached_destination, int64_t this_reply)
+{
+    if (reached_destination) {
+        printf("%s: hop %d reached DESTINATION %s (%s ms)\n", h->host, h->trace_ttl, ip_str, sprint_tm(this_reply));
+        h->trace_ttl = TRACEROUTE_DONE_TTL; /* Goal achieved: artificially increase TTL to stop loop in main_loop */
+    } else {
+        printf("%s: hop %d reached %s (%s ms)\n", h->host, h->trace_ttl, ip_str, sprint_tm(this_reply));
+        h->trace_ttl++;
+        if (h->trace_ttl > (int)opt_ttl) {
+            h->trace_ttl = (int)opt_ttl;
+        }
+    }
+}
 
 /************************************************************
 
@@ -3117,6 +3252,7 @@ void usage(int is_error)
     fprintf(out, "                      except with -l/-c/-C, where it's the -p period up to 2000 ms)\n");
     fprintf(out, "       --check-source discard replies not from target address\n");
     fprintf(out, "       --icmp-timestamp use ICMP Timestamp instead of ICMP Echo\n");
+    fprintf(out, "       --traceroute   Sends a traceroute based on ICMP echo request (Root privileges are required)\n");
     fprintf(out, "\n");
     fprintf(out, "Output options:\n");
     fprintf(out, "   -a, --alive        show targets that are alive\n");

--- a/src/fping.h
+++ b/src/fping.h
@@ -41,6 +41,7 @@ typedef struct host_entry {
     int64_t min_reply_i; /* shortest response time */
     int64_t total_time_i; /* sum of response times */
     int64_t *resp_times; /* individual response times */
+    int trace_ttl; /* current traceroute ttl */
 
     /* to avoid allocating two struct events each time that we send a ping, we
      * preallocate here two struct events for each ping that we might send for
@@ -125,19 +126,20 @@ void print_timestamp_format(int64_t current_time_ns, int timestamp_format);
 void crash_and_burn( char *message );
 void errno_crash_and_burn( char *message );
 int in_cksum( unsigned short *p, int n );
+void handle_traceroute_hop(HOST_ENTRY *h, const char *ip_str, int reached_destination, int64_t this_reply);
 
 /* socket.c */
 int  open_ping_socket_ipv4(int *socktype);
 void socket_set_outgoing_iface_ipv4(int s, const char *iface_name);
 void init_ping_buffer_ipv4(size_t ping_data_size);
 void socket_set_src_addr_ipv4(int s, struct in_addr *src_addr, int *ident);
-int  socket_sendto_ping_ipv4(int s, struct sockaddr *saddr, socklen_t saddr_len, uint16_t icmp_seq, uint16_t icmp_id, uint8_t icmp_proto);
+int socket_sendto_ping_ipv4(int s, struct sockaddr* saddr, socklen_t saddr_len, uint16_t icmp_seq_nr, uint16_t icmp_id_nr, uint8_t icmp_proto, int ttl);
 #ifdef IPV6
 int  open_ping_socket_ipv6(int *socktype);
 void socket_set_outgoing_iface_ipv6(const char *iface_name);
 void init_ping_buffer_ipv6(size_t ping_data_size);
 void socket_set_src_addr_ipv6(int s, struct in6_addr *src_addr, int *ident);
-int  socket_sendto_ping_ipv6(int s, struct sockaddr *saddr, socklen_t saddr_len, uint16_t icmp_seq, uint16_t icmp_id);
+int socket_sendto_ping_ipv6(int s, struct sockaddr* saddr, socklen_t saddr_len, uint16_t icmp_seq_nr, uint16_t icmp_id_nr, int ttl);
 #endif
 
 #endif

--- a/src/socket4.c
+++ b/src/socket4.c
@@ -159,7 +159,7 @@ unsigned short calcsum(unsigned short* buffer, int length)
     return ~sum;
 }
 
-int socket_sendto_ping_ipv4(int s, struct sockaddr* saddr, socklen_t saddr_len, uint16_t icmp_seq_nr, uint16_t icmp_id_nr, uint8_t icmp_proto)
+int socket_sendto_ping_ipv4(int s, struct sockaddr* saddr, socklen_t saddr_len, uint16_t icmp_seq_nr, uint16_t icmp_id_nr, uint8_t icmp_proto, int ttl)
 {
     struct icmp* icp;
     struct timespec tsorig;
@@ -189,26 +189,31 @@ int socket_sendto_ping_ipv4(int s, struct sockaddr* saddr, socklen_t saddr_len, 
 
     icp->icmp_cksum = calcsum((unsigned short*)icp, ping_pkt_size_ipv4);
 
+
+    struct iovec iov = {
+        .iov_base = icp,
+        .iov_len  = ping_pkt_size_ipv4
+    };
+
+    /* Buffer for ancillary data (Interface info and/or TTL) */
+    char cmsg_buf[CMSG_SPACE(sizeof(struct in_pktinfo))];
+    memset(cmsg_buf, 0, sizeof(cmsg_buf));
+
+
+    struct msghdr msg = {
+        .msg_name       = saddr,
+        .msg_namelen    = saddr_len,
+        .msg_iov        = &iov,
+        .msg_iovlen     = 1,
+        .msg_control    = cmsg_buf,
+        .msg_controllen = sizeof(cmsg_buf),
+        .msg_flags      = 0
+    };
+
+    struct cmsghdr *cmsg = CMSG_FIRSTHDR(&msg);
+
     if (outgoing_iface_idx_ipv4 > 0) {
-        struct iovec iov = {
-            .iov_base = icp,
-            .iov_len  = ping_pkt_size_ipv4
-        };
-
-        char cmsg_buf[CMSG_SPACE(sizeof(struct in_pktinfo))];
-        memset(cmsg_buf, 0, sizeof(cmsg_buf));
-
-        struct msghdr msg = {
-            .msg_name       = saddr,
-            .msg_namelen    = saddr_len,
-            .msg_iov        = &iov,
-            .msg_iovlen     = 1,
-            .msg_control    = cmsg_buf,
-            .msg_controllen = sizeof(cmsg_buf),
-            .msg_flags      = 0
-        };
-
-        struct cmsghdr *cmsg = CMSG_FIRSTHDR(&msg);
+        msg.msg_controllen += CMSG_SPACE(sizeof(struct in_pktinfo));
         cmsg->cmsg_level = IPPROTO_IP;
         cmsg->cmsg_type  = IP_PKTINFO;
         cmsg->cmsg_len   = CMSG_LEN(sizeof(struct in_pktinfo));
@@ -219,7 +224,20 @@ int socket_sendto_ping_ipv4(int s, struct sockaddr* saddr, socklen_t saddr_len, 
         if (outgoing_src_addr_set_ipv4) {
             pktinfo->ipi_spec_dst = outgoing_src_addr_ipv4;
         }
+        cmsg = CMSG_NXTHDR(&msg, cmsg);
+    }
 
+    /* Handle TTL */
+    if (ttl > 0) {
+        msg.msg_controllen += CMSG_SPACE(sizeof(int));
+        cmsg->cmsg_level = IPPROTO_IP;
+        cmsg->cmsg_type  = IP_TTL;
+        cmsg->cmsg_len   = CMSG_LEN(sizeof(int));
+        memcpy(CMSG_DATA(cmsg), &ttl, sizeof(int));
+    }
+
+    /* Use sendmsg if we have ancillary data, otherwise fallback to sendto */
+    if (msg.msg_controllen > 0) {
         n = sendmsg(s, &msg, 0);
     } else {
         n = sendto(s, icp, ping_pkt_size_ipv4, 0, saddr, saddr_len);

--- a/src/socket6.c
+++ b/src/socket6.c
@@ -147,7 +147,7 @@ void socket_set_src_addr_ipv6(int s, struct in6_addr* src_addr, int *ident)
     }
 }
 
-int socket_sendto_ping_ipv6(int s, struct sockaddr* saddr, socklen_t saddr_len, uint16_t icmp_seq_nr, uint16_t icmp_id_nr)
+int socket_sendto_ping_ipv6(int s, struct sockaddr* saddr, socklen_t saddr_len, uint16_t icmp_seq_nr, uint16_t icmp_id_nr, int ttl)
 {
     struct icmp6_hdr* icp;
     int n;
@@ -166,38 +166,58 @@ int socket_sendto_ping_ipv6(int s, struct sockaddr* saddr, socklen_t saddr_len, 
 
     icp->icmp6_cksum = 0; /* The IPv6 stack calculates the checksum for us... */
 
+    /* Prepare msghdr for sendmsg */
+    struct iovec iov = {
+        .iov_base = icp,
+        .iov_len  = ping_pkt_size_ipv6
+    };
+
+    /* Buffer for ancillary data (Interface info and/or Hop Limit) */
+    char cmsg_buf[CMSG_SPACE(sizeof(struct in6_pktinfo)) + CMSG_SPACE(sizeof(int))];
+    memset(cmsg_buf, 0, sizeof(cmsg_buf));
+
+    struct msghdr msg = {
+        .msg_name       = saddr,
+        .msg_namelen    = saddr_len,
+        .msg_iov        = &iov,
+        .msg_iovlen     = 1,
+        .msg_control    = cmsg_buf,
+        .msg_controllen = sizeof(cmsg_buf),
+        .msg_flags      = 0
+    };
+
+    size_t actual_cmsg_len = 0;
+    struct cmsghdr *cmsg = CMSG_FIRSTHDR(&msg);
+
+    /* Handle Interface Index and Source Address */
     if (outgoing_iface_idx_ipv6 > 0) {
-        struct iovec iov = {
-            .iov_base = icp,
-            .iov_len  = ping_pkt_size_ipv6
-        };
-
-        char cmsg_buf[CMSG_SPACE(sizeof(struct in6_pktinfo))];
-        memset(cmsg_buf, 0, sizeof(cmsg_buf));
-
-        struct msghdr msg = {
-            .msg_name       = saddr,
-            .msg_namelen    = saddr_len,
-            .msg_iov        = &iov,
-            .msg_iovlen     = 1,
-            .msg_control    = cmsg_buf,
-            .msg_controllen = sizeof(cmsg_buf),
-            .msg_flags      = 0
-        };
-
-        struct cmsghdr *cmsg = CMSG_FIRSTHDR(&msg);
+        msg.msg_controllen += CMSG_SPACE(sizeof(struct in6_pktinfo));
         cmsg->cmsg_level = IPPROTO_IPV6;
         cmsg->cmsg_type  = IPV6_PKTINFO;
         cmsg->cmsg_len   = CMSG_LEN(sizeof(struct in6_pktinfo));
 
         struct in6_pktinfo *pktinfo = (struct in6_pktinfo *)CMSG_DATA(cmsg);
-        memset(pktinfo, 0, sizeof(*pktinfo));
         pktinfo->ipi6_ifindex = outgoing_iface_idx_ipv6;
-
         if (outgoing_src_addr_set_ipv6) {
             pktinfo->ipi6_addr = outgoing_src_addr_ipv6;
         }
+        actual_cmsg_len += CMSG_SPACE(sizeof(struct in6_pktinfo));
+        cmsg = CMSG_NXTHDR(&msg, cmsg);
+    }
 
+    /* Handle Hop Limit (TTL) */
+    if (ttl > 0 && cmsg != NULL) {
+        cmsg->cmsg_level = IPPROTO_IPV6;
+        cmsg->cmsg_type  = IPV6_HOPLIMIT;
+        cmsg->cmsg_len   = CMSG_LEN(sizeof(int));
+        memcpy(CMSG_DATA(cmsg), &ttl, sizeof(int));
+        actual_cmsg_len += CMSG_SPACE(sizeof(int));
+    }
+
+    msg.msg_controllen = actual_cmsg_len;
+
+    /* Use sendmsg if we have ancillary data, otherwise fallback to sendto */
+    if (msg.msg_controllen > 0) {
         n = sendmsg(s, &msg, 0);
     } else {
         n = sendto(s, icp, ping_pkt_size_ipv6, 0, saddr, saddr_len);


### PR DESCRIPTION
The traceroute function is now complete. There is no JSON output in the current version, and testing is still pending, if it is even possible given the required root privileges.
IPv6 also works.

`./fping --traceroute 8.8.8.8`

**Output**
```
fping traceroute to 127.0.0.1 (127.0.0.1), 30 hops max, 84 byte packets
127.0.0.1: hop 1 reached DESTINATION 127.0.0.1 (0.055 ms)
```

**Test Checklist**
| Option | Test | Supported |
| ---------- | ------ | --------------- |
| --ipv4 (-4) | Yes | Yes |
| --ipv6 (-6) | Yes | Yes |
| --alive (-a) | Yes | No (No effect) |
| --addr (-A) | Yes | Yes |
| --size (-b) | Yes | Yes (I couldn't really check the results and effects.) |
| --backoff (-B) | Yes | No (No effect) |
| --count (-c) | Yes  | No  |
| --vcount (-C) | Yes  | No |
| --rdns (-d) | Yes | Yes |
| --timestamp (-D) | Yes | No |
| --elapsed (-e) | Yes | No (No effect) |
| --file (-f) |  |  |
| --generate (-g) |  |  |
| --ttl (-H) | Yes  | Yes (1-30) |
| --interval (-i) | Yes | Yes |
| --iface (-I) | No | Yes (Untested) |
| --json (-j) | No | No (Next version) |
| --icmp-timestamp |  |  |
| --fwmark (-k) | No | No (Untested) |
| --loop (-l) | Yes  | No |
| --all (-m) | Yes | No (No effect) |
| --dontfrag (-M) | Yes | Yes |
| --name (-n) | Yes | Yes |
| --netdata (-N) | Yes  | No |
| --outage (-o) |  |  |
| --tos (-O) | Yes  | Yes |
| --period (-p) | Yes | Yes (same effect as -i) |
| --quiet (-q) | Yes | No |
| --squiet (-Q) | Yes | No |
| --retry (-r) | Yes | No (No effect) |
| --random (-R) | Yes | Yes |
| --stats (-s) | Yes | No (Works, but the output is misleading) |
| --src (-S) | No | Yes (Untested) |
| --timeout (-t) | Yes | No (No effect) |
| (-T) |  |  |
| --unreach (-u) | Yes | No (No effect)  |
| --retry (-r) | Yes | No (No effect)  |
| --fast-reachable (-X) |  |  |
| --check-source | Yes | Yes |
| --print-tos | Yes | No |
| --print-ttl | Yes | No |
| --seqmap-timeout |  |  |
| (-z) |  |  |