### PR TITLE
better Netbsd compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Next
 - ci: Removed travis-ci (#446, thanks @gsnw-sebast)
 - Performance optimization: reduce number of select calls and use
   recvmsg with MSG_DONTWAIT instead (#449)
+- Improved compatibility with NetBSD (#452, thanks @auerswal)
 
 fping 5.5 (2025-12-31)
 ======================

--- a/configure.ac
+++ b/configure.ac
@@ -39,7 +39,7 @@ AS_IF([test "x$enable_ipv6" != "xno"], [
       #include <sys/types.h>
   ]])
 ])
-AS_IF([test "x$have_ipv6" == "xyes"], [
+AS_IF([test "x$have_ipv6" = "xyes"], [
     dnl Test if IPv6 is supported
        AC_CHECK_HEADERS([netinet/ip6.h], [have_ipv6="yes"], [have_ipv6="no"], [[
       #include <netinet/in.h>

--- a/src/fping.c
+++ b/src/fping.c
@@ -712,11 +712,13 @@ int main(int argc, char **argv)
                 ping_data_size = ICMP_TIMESTAMP_DATA_SIZE;
             } else if (strstr(optparse_state.optlongname, "print-tos") != NULL) {
                 print_tos_flag = 1;
+#if defined(IP_RECVTOS)
                 if (socket4 >= 0 && (socktype4 == SOCK_DGRAM)) {
                     if (setsockopt(socket4, IPPROTO_IP, IP_RECVTOS, &sock_opt_on, sizeof(sock_opt_on))) {
                         perror("setsockopt IP_RECVTOS");
                     }
                 }
+#endif
 #if defined(IPV6) && defined(IPV6_RECVTCLASS)
                 if (socket6 >= 0) {
                     if (setsockopt(socket6, IPPROTO_IPV6, IPV6_RECVTCLASS, &sock_opt_on, sizeof(sock_opt_on))) {


### PR DESCRIPTION
Improve portability to NetBSD by adapting two patches from the NetBSD package <https://cvsweb.netbsd.org/bsdweb.cgi/pkgsrc/net/fping/>. This addresses GH issue #450.