### PR TITLE
ci: Update autoconf to version 2.73

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Next
   function declarations to a separate file (#454, thanks @gsnw-sebast)
 - Avoid crash with option `-0` (#457, thanks @auerswal)
 - Move option parsing to a separate file fping.c and fping.h (#458, thanks @gsnw-sebast)
+- ci: Update autoconf to version 2.73 (#467, thanks @gsnw-sebast)
 
 fping 5.5 (2025-12-31)
 ======================

--- a/ci/build-1-autotools.sh
+++ b/ci/build-1-autotools.sh
@@ -15,7 +15,7 @@ MIRRORS=(
     https://ftp.gnu.org/gnu
 )
 
-AUTOCONF_REL=autoconf/autoconf-2.72.tar.gz
+AUTOCONF_REL=autoconf/autoconf-2.73.tar.gz
 AUTOMAKE_REL=automake/automake-1.18.1.tar.gz
 LIBTOOL_REL=libtool/libtool-2.5.4.tar.gz
 


### PR DESCRIPTION
A new version of autoconf was released on Fri, Mar 20, 2026, at 3:47:42 PM -0400

https://lists.gnu.org/archive/html/autoconf/2026-03/msg00060.html