### PR TITLE
Fix getprotobyname missing on Android preventing use

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -10,7 +10,7 @@ m4_ifdef([AC_AUTOCONF_VERSION],[AC_USE_SYSTEM_EXTENSIONS], [AC_GNU_SOURCE])
 # Detect Operatingsystem
 AC_CANONICAL_TARGET
 only_clock_realtime=no
-use_getprotobyname=yes
+disable_getprotobyname=no
 
 case "${target}" in
   *darwin*)
@@ -23,7 +23,7 @@ case "${target}" in
     only_clock_realtime=yes
     ;;
   *android*)
-    use_getprotobyname=no
+    disable_getprotobyname=yes
     ;;
 esac
 
@@ -108,7 +108,20 @@ AC_ARG_ENABLE([debug],
 AS_IF([test "x$enable_debug" = "xyes"], [
   AC_DEFINE([DEBUG], [1], [Define if debugging is enabled])])
 
-AS_IF([test "x$use_getprotobyname" = "xyes"], [AC_DEFINE([USE_GETPROTOBYNAME], [1], [Enable use of getprotobyname])])
+AS_IF([test "x$only_clock_realtime" = "xyes"], [AC_DEFINE(ONLY_CLOCK_REALTIME, [1], [ONLY_CLOCK_REALTIME is defined])])
+
+dnl check for getprotobyname support
+
+AC_CHECK_FUNCS([getprotobyname])
+
+AS_IF([test "x$disable_getprotobyname" = "xyes"], [
+  AC_MSG_NOTICE([Android detected: Disabling getprotobyname])
+  ac_cv_func_getprotobyname=no
+])
+
+if test $ac_cv_func_getprotobyname = yes; then
+  AC_DEFINE([USE_GETPROTOBYNAME], [1], [Define if getprotobyname is available and should be used.])
+fi
 
 AM_INIT_AUTOMAKE([-Wall -Werror foreign])
 AM_MAINTAINER_MODE

--- a/configure.ac
+++ b/configure.ac
@@ -104,6 +104,14 @@ AC_ARG_ENABLE([debug],
 AS_IF([test "x$enable_debug" = "xyes"], [
   AC_DEFINE([DEBUG], [1], [Define if debugging is enabled])])
 
+
+AC_ARG_ENABLE([getprotobyname],
+  AS_HELP_STRING([--disable-getprotobyname], [Disable use of getprotobyname]),
+  [], [enable_getprotobyname=yes])
+AS_IF([test "x$enable_getprotobyname" = "xyes"], [
+  AC_DEFINE([USE_GETPROTOBYNAME], [1], [Enable use of getprotobyname])
+])
+
 AM_INIT_AUTOMAKE([-Wall -Werror foreign])
 AM_MAINTAINER_MODE
 

--- a/configure.ac
+++ b/configure.ac
@@ -10,7 +10,6 @@ m4_ifdef([AC_AUTOCONF_VERSION],[AC_USE_SYSTEM_EXTENSIONS], [AC_GNU_SOURCE])
 # Detect Operatingsystem
 AC_CANONICAL_TARGET
 only_clock_realtime=no
-use_getprotobyname=yes
 
 case "${target}" in
   *darwin*)
@@ -21,9 +20,6 @@ case "${target}" in
     ;;
   *openbsd*)
     only_clock_realtime=yes
-    ;;
-  *android*)
-    use_getprotobyname=no
     ;;
 esac
 
@@ -107,8 +103,6 @@ AC_ARG_ENABLE([debug],
   AS_HELP_STRING([--enable-debug], [enable debugging @<:@default=no@:>@]), [enable_debug=$enableval], [enable_debug=no])
 AS_IF([test "x$enable_debug" = "xyes"], [
   AC_DEFINE([DEBUG], [1], [Define if debugging is enabled])])
-
-AS_IF([test "x$use_getprotobyname" = "xyes"], [AC_DEFINE([USE_GETPROTOBYNAME], [1], [Enable use of getprotobyname])])
 
 AM_INIT_AUTOMAKE([-Wall -Werror foreign])
 AM_MAINTAINER_MODE

--- a/configure.ac
+++ b/configure.ac
@@ -10,6 +10,7 @@ m4_ifdef([AC_AUTOCONF_VERSION],[AC_USE_SYSTEM_EXTENSIONS], [AC_GNU_SOURCE])
 # Detect Operatingsystem
 AC_CANONICAL_TARGET
 only_clock_realtime=no
+use_getprotobyname=yes
 
 case "${target}" in
   *darwin*)
@@ -20,6 +21,9 @@ case "${target}" in
     ;;
   *openbsd*)
     only_clock_realtime=yes
+    ;;
+  *android*)
+    use_getprotobyname=no
     ;;
 esac
 
@@ -104,13 +108,7 @@ AC_ARG_ENABLE([debug],
 AS_IF([test "x$enable_debug" = "xyes"], [
   AC_DEFINE([DEBUG], [1], [Define if debugging is enabled])])
 
-
-AC_ARG_ENABLE([getprotobyname],
-  AS_HELP_STRING([--disable-getprotobyname], [Disable use of getprotobyname]),
-  [], [enable_getprotobyname=yes])
-AS_IF([test "x$enable_getprotobyname" = "xyes"], [
-  AC_DEFINE([USE_GETPROTOBYNAME], [1], [Enable use of getprotobyname])
-])
+AS_IF([test "x$use_getprotobyname" = "xyes"], [AC_DEFINE([USE_GETPROTOBYNAME], [1], [Enable use of getprotobyname])])
 
 AM_INIT_AUTOMAKE([-Wall -Werror foreign])
 AM_MAINTAINER_MODE

--- a/src/socket4.c
+++ b/src/socket4.c
@@ -59,20 +59,23 @@ static int outgoing_src_addr_set_ipv4 = 0;
 
 int open_ping_socket_ipv4(int *socktype)
 {
-    struct protoent* proto;
-    int s;
+    int s = -1;
+    int p_proto = IPPROTO_ICMP;
 
-    /* confirm that ICMP is available on this machine */
-    if ((proto = getprotobyname("icmp")) == NULL)
-        crash_and_burn("icmp: unknown protocol");
+#if defined(USE_GETPROTOBYNAME) && !(defined(ANDROID) || defined(__ANDROID__))
+	/* confirm that ICMP is available on this machine */
+	if (getprotobyname("icmp") == NULL) {
+		crash_and_burn("icmp: unknown protocol");
+	}
+#endif
 
     /* create raw socket for ICMP calls (ping) */
     *socktype = SOCK_RAW;
-    s = socket(AF_INET, *socktype, proto->p_proto);
+    s = socket(AF_INET, *socktype, p_proto);
     if (s < 0) {
         /* try non-privileged icmp (works on Mac OSX without privileges, for example) */
         *socktype = SOCK_DGRAM;
-        s = socket(AF_INET, *socktype, proto->p_proto);
+        s = socket(AF_INET, *socktype, p_proto);
         if (s < 0) {
             return -1;
         }

--- a/src/socket4.c
+++ b/src/socket4.c
@@ -59,27 +59,13 @@ static int outgoing_src_addr_set_ipv4 = 0;
 
 int open_ping_socket_ipv4(int *socktype)
 {
-    int s = -1;
-    int p_proto = IPPROTO_ICMP;
-
-#ifdef USE_GETPROTOBYNAME
-    {
-        /* confirm that ICMP is available on this machine */
-        struct protoent* proto = getprotobyname("icmp");
-        if (proto == NULL) {
-            crash_and_burn("icmp: unknown protocol");
-        }
-        p_proto = proto->p_proto;
-    }
-#endif
-
     /* create raw socket for ICMP calls (ping) */
     *socktype = SOCK_RAW;
-    s = socket(AF_INET, *socktype, p_proto);
+    int s = socket(AF_INET, *socktype, IPPROTO_ICMP);
     if (s < 0) {
         /* try non-privileged icmp (works on Mac OSX without privileges, for example) */
         *socktype = SOCK_DGRAM;
-        s = socket(AF_INET, *socktype, p_proto);
+        s = socket(AF_INET, *socktype, IPPROTO_ICMP);
         if (s < 0) {
             return -1;
         }

--- a/src/socket4.c
+++ b/src/socket4.c
@@ -63,10 +63,14 @@ int open_ping_socket_ipv4(int *socktype)
     int p_proto = IPPROTO_ICMP;
 
 #ifdef USE_GETPROTOBYNAME
-	/* confirm that ICMP is available on this machine */
-	if (getprotobyname("icmp") == NULL) {
-		crash_and_burn("icmp: unknown protocol");
-	}
+    {
+        /* confirm that ICMP is available on this machine */
+        struct protoent* proto = getprotobyname("icmp");
+        if (proto == NULL) {
+            crash_and_burn("icmp: unknown protocol");
+        }
+        p_proto = proto->p_proto;
+    }
 #endif
 
     /* create raw socket for ICMP calls (ping) */

--- a/src/socket4.c
+++ b/src/socket4.c
@@ -62,7 +62,7 @@ int open_ping_socket_ipv4(int *socktype)
     int s = -1;
     int p_proto = IPPROTO_ICMP;
 
-#if defined(USE_GETPROTOBYNAME) && !(defined(ANDROID) || defined(__ANDROID__))
+#ifdef USE_GETPROTOBYNAME
 	/* confirm that ICMP is available on this machine */
 	if (getprotobyname("icmp") == NULL) {
 		crash_and_burn("icmp: unknown protocol");

--- a/src/socket6.c
+++ b/src/socket6.c
@@ -61,11 +61,16 @@ int open_ping_socket_ipv6(int *socktype)
     int p_proto = IPPROTO_ICMPV6;
 
 #ifdef USE_GETPROTOBYNAME
-	/* confirm that ICMP6 is available on this machine */
-	if (getprotobyname("ipv6-icmp") == NULL ) {
-		crash_and_burn("ipv6-icmp: unknown protocol");
-	}
+    {
+        /* confirm that ICMP6 is available on this machine */
+        struct protoent* proto = getprotobyname("ipv6-icmp");
+        if (proto == NULL) {
+            crash_and_burn("ipv6-icmp: unknown protocol");
+        }
+        p_proto = proto->p_proto;
+    }
 #endif
+
 
     /* create raw socket for ICMP6 calls (ping) */
     *socktype = SOCK_RAW;

--- a/src/socket6.c
+++ b/src/socket6.c
@@ -61,10 +61,10 @@ int open_ping_socket_ipv6(int *socktype)
     int p_proto = IPPROTO_ICMPV6;
 
 #if defined(USE_GETPROTOBYNAME) && !(defined(ANDROID) || defined(__ANDROID__))
-	/* confirm that ICMP6 is available on this machine */
-	if (getprotobyname("ipv6-icmp") == NULL ) {
-		crash_and_burn("ipv6-icmp: unknown protocol");
-	}
+    /* confirm that ICMP6 is available on this machine */
+    if (getprotobyname("ipv6-icmp") == NULL) {
+        crash_and_burn("ipv6-icmp: unknown protocol");
+    }
 #endif
 
     /* create raw socket for ICMP6 calls (ping) */

--- a/src/socket6.c
+++ b/src/socket6.c
@@ -57,27 +57,13 @@ static int outgoing_src_addr_set_ipv6 = 0;
 
 int open_ping_socket_ipv6(int *socktype)
 {
-    int s = -1;
-    int p_proto = IPPROTO_ICMPV6;
-
-#ifdef USE_GETPROTOBYNAME
-    {
-        /* confirm that ICMP6 is available on this machine */
-        struct protoent* proto = getprotobyname("ipv6-icmp");
-        if (proto == NULL) {
-            crash_and_burn("ipv6-icmp: unknown protocol");
-        }
-        p_proto = proto->p_proto;
-    }
-#endif
-
     /* create raw socket for ICMP6 calls (ping) */
     *socktype = SOCK_RAW;
-    s = socket(AF_INET6, *socktype, p_proto);
+    int s = socket(AF_INET6, *socktype, IPPROTO_ICMPV6);
     if (s < 0) {
         /* try non-privileged icmp6 (works on Mac OSX without privileges, for example) */
         *socktype = SOCK_DGRAM;
-        s = socket(AF_INET6, *socktype, p_proto);
+        s = socket(AF_INET6, *socktype, IPPROTO_ICMPV6);
         if (s < 0) {
             return -1;
         }

--- a/src/socket6.c
+++ b/src/socket6.c
@@ -60,7 +60,7 @@ int open_ping_socket_ipv6(int *socktype)
     int s = -1;
     int p_proto = IPPROTO_ICMPV6;
 
-#if defined(USE_GETPROTOBYNAME) && !(defined(ANDROID) || defined(__ANDROID__))
+#ifdef USE_GETPROTOBYNAME
 	/* confirm that ICMP6 is available on this machine */
 	if (getprotobyname("ipv6-icmp") == NULL ) {
 		crash_and_burn("ipv6-icmp: unknown protocol");

--- a/src/socket6.c
+++ b/src/socket6.c
@@ -57,20 +57,23 @@ static int outgoing_src_addr_set_ipv6 = 0;
 
 int open_ping_socket_ipv6(int *socktype)
 {
-    struct protoent* proto;
-    int s;
+    int s = -1;
+    int p_proto = IPPROTO_ICMPV6;
 
-    /* confirm that ICMP6 is available on this machine */
-    if ((proto = getprotobyname("ipv6-icmp")) == NULL)
-        crash_and_burn("ipv6-icmp: unknown protocol");
+#if defined(USE_GETPROTOBYNAME) && !(defined(ANDROID) || defined(__ANDROID__))
+	/* confirm that ICMP6 is available on this machine */
+	if (getprotobyname("ipv6-icmp") == NULL ) {
+		crash_and_burn("ipv6-icmp: unknown protocol");
+	}
+#endif
 
     /* create raw socket for ICMP6 calls (ping) */
     *socktype = SOCK_RAW;
-    s = socket(AF_INET6, *socktype, proto->p_proto);
+    s = socket(AF_INET6, *socktype, p_proto);
     if (s < 0) {
         /* try non-privileged icmp6 (works on Mac OSX without privileges, for example) */
         *socktype = SOCK_DGRAM;
-        s = socket(AF_INET6, *socktype, proto->p_proto);
+        s = socket(AF_INET6, *socktype, p_proto);
         if (s < 0) {
             return -1;
         }

--- a/src/socket6.c
+++ b/src/socket6.c
@@ -71,7 +71,6 @@ int open_ping_socket_ipv6(int *socktype)
     }
 #endif
 
-
     /* create raw socket for ICMP6 calls (ping) */
     *socktype = SOCK_RAW;
     s = socket(AF_INET6, *socktype, p_proto);


### PR DESCRIPTION
`getprotobyname` is [stubbed out on Android](https://android.googlesource.com/platform/bionic/+/089111a80a6a167de827bf32ae2d2a935ff5874f%5E2..089111a80a6a167de827bf32ae2d2a935ff5874f/) causing crash_and_burn to be called. This commit removes the ICMP support check when compiling for Android and adds a configuration option to compile without `getprotobyname` check.