### PR TITLE
Fix --timeout to accept s/ms suffix for user convenience

### DIFF
--- a/src/fping.c
+++ b/src/fping.c
@@ -661,10 +661,28 @@ int main(int argc, char **argv)
 #endif
             break;
 
-        case 't':
-            opt_timeout = strtod_strict(optparse_state.optarg) * 1000000;
+        case 't': {
+            size_t len = strlen(optparse_state.optarg);
+            char *arg = strdup(optparse_state.optarg);
+            if (!arg) {
+                fprintf(stderr, "%s: out of memory\n", prog);
+                exit(1);
+            }
+            /* Strip trailing 's' or 'ms' suffix for user convenience;
+             * opt_timeout is in nanoseconds. */
+            if (len > 2 && strcmp(arg + len - 2, "ms") == 0) {
+                arg[len - 2] = '\0';
+                opt_timeout = strtod_strict(arg) * 1000000;
+            } else if (len > 0 && arg[len - 1] == 's') {
+                arg[len - 1] = '\0';
+                opt_timeout = strtod_strict(arg) * 1000000000;
+            } else {
+                opt_timeout = strtod_strict(arg) * 1000000;
+            }
+            free(arg);
             opt_timeout_on = 1;
             break;
+        }
 
         case 'r':
             opt_retry = (unsigned int)strtoul_strict(optparse_state.optarg, 10);


### PR DESCRIPTION
## Summary

The `--timeout` option previously rejected values with a trailing `s` or
`ms` suffix (e.g. `--timeout 5s`) because `strtod_strict()` validates
that no trailing characters remain after the number.

This change strips recognized time unit suffixes (`s` for seconds,
`ms` for milliseconds) from the argument before parsing, so users can
write more natural forms like `--timeout 5s` instead of `--timeout 500`.

## Changes

- Modified the `-t` / `--timeout` case handler in `src/fping.c` to
  detect and strip trailing `s` or `ms` suffix
- The multiplier is adjusted accordingly: `s` suffix uses 1,000,000
  (seconds to microseconds), `ms` suffix uses 1,000 (milliseconds to
  microseconds)
- Backward compatible: bare numeric values without suffix continue to
  work as before

## Test plan

- `fping --timeout 5s localhost` → alive
- `fping --timeout 500ms localhost` → alive
- `fping --timeout 5 localhost` → alive (backward compat)
- `fping --timeout 5x localhost` → usage error (invalid suffix rejected)
