### PR TITLE
Fix getprotobyname missing on Android preventing use (by Paliak #470)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Next
 
 ## Bugfixes and other changes
 
+- Fix getprotobyname missing on Android preventing use (#470, thanks Paliak. Merged #475)
 - ci: Removed travis-ci (#446, thanks @gsnw-sebast)
 - Performance optimization: reduce number of select calls and use
   recvmsg with MSG_DONTWAIT instead (#449)

--- a/src/socket4.c
+++ b/src/socket4.c
@@ -59,20 +59,15 @@ static int outgoing_src_addr_set_ipv4 = 0;
 
 int open_ping_socket_ipv4(int *socktype)
 {
-    struct protoent* proto;
     int s;
-
-    /* confirm that ICMP is available on this machine */
-    if ((proto = getprotobyname("icmp")) == NULL)
-        crash_and_burn("icmp: unknown protocol");
 
     /* create raw socket for ICMP calls (ping) */
     *socktype = SOCK_RAW;
-    s = socket(AF_INET, *socktype, proto->p_proto);
+    s = socket(AF_INET, *socktype, IPPROTO_ICMP);
     if (s < 0) {
         /* try non-privileged icmp (works on Mac OSX without privileges, for example) */
         *socktype = SOCK_DGRAM;
-        s = socket(AF_INET, *socktype, proto->p_proto);
+        s = socket(AF_INET, *socktype, IPPROTO_ICMP);
         if (s < 0) {
             return -1;
         }

--- a/src/socket6.c
+++ b/src/socket6.c
@@ -57,20 +57,15 @@ static int outgoing_src_addr_set_ipv6 = 0;
 
 int open_ping_socket_ipv6(int *socktype)
 {
-    struct protoent* proto;
     int s;
-
-    /* confirm that ICMP6 is available on this machine */
-    if ((proto = getprotobyname("ipv6-icmp")) == NULL)
-        crash_and_burn("ipv6-icmp: unknown protocol");
 
     /* create raw socket for ICMP6 calls (ping) */
     *socktype = SOCK_RAW;
-    s = socket(AF_INET6, *socktype, proto->p_proto);
+    s = socket(AF_INET6, *socktype, IPPROTO_ICMPV6);
     if (s < 0) {
         /* try non-privileged icmp6 (works on Mac OSX without privileges, for example) */
         *socktype = SOCK_DGRAM;
-        s = socket(AF_INET6, *socktype, proto->p_proto);
+        s = socket(AF_INET6, *socktype, IPPROTO_ICMPV6);
         if (s < 0) {
             return -1;
         }


### PR DESCRIPTION
Due to the merge conflict, I created a new pull-request based on #470.
Thanks, Paliak for the change.